### PR TITLE
Slovenian translation: Add configuration file with auto-import

### DIFF
--- a/orange3/trubar-config.yaml
+++ b/orange3/trubar-config.yaml
@@ -1,0 +1,1 @@
+auto-import: "from Orange.widgets.utils.localization import plsi, plsi_sz  # pylint: disable=wrong-import-order"


### PR DESCRIPTION
Import `plsi` and `plsi_sz`.

This way, Orange will no longer have to use those ugly wildcard imports from `Orange.widgets.utils.localizations`.