### PR TITLE
Remove syntax checking; use released trubar

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install git+https://github.com/janezd/trubar.git#egg=trubar
+        python -m pip install trubar
         git clone https://github.com/biolab/orange3.git orange3-orig
-    - name: Translate and check syntax
+    - name: Translate
       run: |
         trubar --conf orange3/trubar-config.yaml translate -s orange3-orig/Orange -d orange3-trans/Orange orange3/si.yaml
-        find orange3-trans -name "*.py" -exec python -m compileall -q {} \;


### PR DESCRIPTION
- Trubar uses ast to generate translated code, so it is very unlikely to contain syntactic errors. Pointless checking just slows down the tests.
- Use the released version of trubar instead of git master.