### PR TITLE
Si: Add utf-8 encoding to config

### DIFF
--- a/si/trubar-config.yaml
+++ b/si/trubar-config.yaml
@@ -1,1 +1,2 @@
 auto-import: "from orangecanvas.utils.localization.si import plsi, plsi_sz, z_besedo  # pylint: disable=wrong-import-order"
+encoding: "utf-8"


### PR DESCRIPTION
Trubar on Windows may expect a different (wrong) encoding. Set it to UTF-8.