### PR TITLE
SI: Translations of tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,17 @@ jobs:
         trubar translate -s orange-canvas-core/orangecanvas -d trans/orange-canvas-core/orangecanvas --static si/orange-canvas-static si/orange-canvas-core.yaml
         trubar translate -s orange-widget-base/orangewidget -d trans/orange-widget-base/orangewidget si/orange-widget-base.yaml
         trubar translate -s orange3/Orange -d trans/orange3/Orange si/orange3.jaml
+        trubar --conf si/test_config.yaml translate -p test_ -s orange3/Orange -d trans/orange3/Orange si/orange3-tests.jaml
     - name: Checkout and translate add-ons
       run: |
         for translation in si/orange3-*.jaml
         do
           name=${translation/si\/orange3-}
+          name=${name/.jaml}
+          if [[ $name == "tests" ]]
+          then
+            continue
+          fi
           name=${name/.jaml}
           git clone https://github.com/biolab/orange3-$name.git
           trubar translate -s orange3-$name/orangecontrib/$name -d trans/orange3-$name/orangecontrib/$name si/orange3-$name.jaml

--- a/si/orange-widget-base.yaml
+++ b/si/orange-widget-base.yaml
@@ -281,8 +281,8 @@ settings.py:
             ): false
 version.py:
     4.20.0: false
-    4.20.0.dev0+5c7b451: false
-    5c7b4516741fcbd2cfca1c6bae8485bd32713d78: false
+    4.20.0.dev0+12431b7: null
+    12431b706930fa29d882b62e8e6a43650206a3c6: null
     .dev: false
 widget.py:
     OWBaseWidget: false
@@ -357,7 +357,7 @@ widget.py:
             menu-view: false
             '&Window': '&Okno'
             menu-window: false
-            '&Help': 'Pomoč'
+            '&Help': Pomoč
             help-menu: false
             Quick Help Tip: Nasvet za hitro pomoč
             action-quick-help-tip: false
@@ -714,6 +714,7 @@ tests/base.py:
         def `wait_for_finished`:
             OWBaseWidget: false
     class `GuiTest`:
+        English: Slovenian
         def `setUpClass`:
             '-': false
             -widgetcount: false
@@ -722,6 +723,11 @@ tests/base.py:
         def `tearDownClass`:
             pyqtgraph: false
             exitCleanup: false
+        def `skipNonEnglish`:
+            English: false
+        def `runOnLanguage`:
+            def `decorator`:
+                Test is valid only for {lang} release: null
     class `WidgetTest`:
         def `__init_subclass__`:
             def `test_minimum_size`:
@@ -827,7 +833,6 @@ utils/__init__.py:
         utf-16-le: false
     def `grapheme_slice`:
         negative start or end: false
-utils/buttons.py: {}
 utils/cache.py:
     class `LRUCache`:
         __dict: false
@@ -1117,7 +1122,8 @@ utils/messagewidget.py:
         '{nwarnings} {pl(nwarnings, ''warning'')}': '{nwarnings} {plsi(nwarnings,
             ''opozorilo|opozorili|opozorila|opozoril'')}'
         '{ninfo} {pl(ninfo, ''message'')}': '{ninfo} {plsi(ninfo, ''sporočilo|sporočili|sporočila|sporočil'')}'
-        '{ninfo} other {pl(ninfo, ''message'')}': '{ninfo} {plsi(ninfo, ''drugo sporočilo|drugi sporočili|druga sporočila|drugih sporočil'')}'
+        '{ninfo} other {pl(ninfo, ''message'')}': '{ninfo} {plsi(ninfo, ''drugo sporočilo|drugi
+            sporočili|druga sporočila|drugih sporočil'')}'
         ' (': true
         ', ': true
         ): true
@@ -1557,7 +1563,8 @@ workflow/mainwindow.py:
             a: false
             def `restart`:
                 Restart Cancelled: Ponovni zagon preklican
-                Settings will be reset on {name}'s next restart: Nastavitve bodo ponastavljene ob naslednjem ponovnem zagonu
+                Settings will be reset on {name}'s next restart: Nastavitve bodo ponastavljene
+                    ob naslednjem ponovnem zagonu
         def `ask_save_report`:
             Report window: Shranjevanje poročila
             The report contains unsaved changes.: Poročilom vsebuje neshranjene spremembe.

--- a/si/orange3-tests.jaml
+++ b/si/orange3-tests.jaml
@@ -1,0 +1,14731 @@
+canvas/tests/test_mainwindow.py:
+    class `TestMainWindow`:
+        def `test_settings_dialog`:
+            exec: null
+            show: null
+classification/tests/test_base.py:
+    class `TestModelMapping`:
+        def `setUpClass`:
+            iris: null
+        def `test_no_common_values`:
+            iris: null
+            abc: null
+    __main__: null
+classification/tests/test_calibration.py:
+    class `TestThresholdClassifier`:
+        def `setUp`:
+            a: null
+            b: null
+        def `test_non_binary_base`:
+            a: null
+            b: null
+            c: null
+        def `test_np_data`:
+            heart_disease: null
+    class `TestThresholdLearner`:
+        def `test_fit_storage`:
+            Orange.evaluation.performance_curves.Curves.from_results: null
+            Orange.classification.calibration.TestOnTrainingData: null
+            a: null
+            b: null
+            heart_disease: null
+            store_models: null
+        def `test_non_binary_class`:
+            a: null
+            b: null
+            c: null
+    class `TestCalibratedClassifier`:
+        def `setUp`:
+            a: null
+            b: null
+        def `test_np_data`:
+            heart_disease: null
+    class `TestCalibratedLearner`:
+        def `test_fit_storage`:
+            Orange.classification.calibration._SigmoidCalibration.fit: null
+            Orange.classification.calibration.TestOnTrainingData: null
+            heart_disease: null
+            a: null
+            b: null
+            store_models: null
+    __main__: null
+classification/tests/test_catgb_cls.py:
+    class `TestCatGBClassifier`:
+        Missing 'catboost' package: null
+        def `setUpClass`:
+            iris: null
+        def `test_set_params`:
+            n_estimators: null
+            max_depth: null
+        def `test_discrete_variables`:
+            zoo: null
+            titanic: null
+        def `test_missing_values`:
+            heart_disease: null
+        def `test_retain_x`:
+            heart_disease: null
+        def `test_doesnt_modify_data`:
+            iris: null
+    __main__: null
+classification/tests/test_gb_cls.py:
+    class `TestGBClassifier`:
+        def `setUpClass`:
+            iris: null
+        def `test_set_params`:
+            n_estimators: null
+            max_depth: null
+    __main__: null
+classification/tests/test_outlier_detection.py:
+    class `_TestDetector`:
+        def `setUpClass`:
+            iris: null
+        def `assert_table_appended_outlier`:
+            Outlier: null
+    class `TestOneClassSVMLearner`:
+        def `test_OneClassSVM`:
+            c1: null
+            c2: null
+        def `test_OneClassSVM_ignores_y`:
+            x1: null
+            x2: null
+            y1: null
+            y2: null
+    class `TestEllipticEnvelopeLearner`:
+        def `setUpClass`:
+            c1: null
+            c2: null
+        def `test_single_data_to_model_domain`:
+            data_to_model_domain: null
+        def `test_EllipticEnvelope_ignores_y`:
+            x1: null
+            x2: null
+            y1: null
+            y2: null
+        def `test_transform`:
+            Mahalanobis: null
+    class `TestOutlierModel`:
+        def `test_unique_name`:
+            Outlier: null
+            Outlier (1): null
+        def `test_transformer`:
+            Outlier: null
+        def `test_pickle_model`:
+            .pkl: null
+        def `test_pickle_prediction`:
+            .pkl: null
+    __main__: null
+classification/tests/test_simple_tree.py:
+    class `SimpleTreeTest`:
+        def `test_nonan_classification`:
+            x: null
+            y: null
+            ab: null
+        def `test_nonan_regression`:
+            x: null
+            y: null
+            x2: null
+        def `test_stub`:
+            x: null
+            y: null
+    __main__: null
+classification/tests/test_xgb_cls.py:
+    class `TestXGBCls`:
+        Missing 'xgboost' package: null
+        def `setUpClass`:
+            iris: null
+        def `test_set_params`:
+            n_estimators: null
+            max_depth: null
+    __main__: null
+data/tests/test_aggregate.py:
+    def `create_sample_data`:
+        a: null
+        b: null
+        cvar: null
+        dvar: null
+        val1: null
+        val2: null
+        svar: null
+        sval1: null
+        sval2: null
+    class `DomainTest`:
+        def `test_simple_aggregation`:
+            a: null
+            mean: null
+            b: null
+            a - mean: null
+            b - mean: null
+        def `test_aggregation`:
+            a: null
+            b: null
+            cvar: null
+            Mean: null
+            mean: null
+            Median: null
+            median: null
+            Mean1: null
+            dvar: null
+            Count defined: null
+            count: null
+            Count: null
+            size: null
+            svar: null
+            Concatenate: null
+            cvar - Mean: null
+            cvar - Median: null
+            cvar - Mean1: null
+            dvar - Count defined: null
+            dvar - Count: null
+            svar - Concatenate: null
+            sval1sval2: null
+            sval2: null
+            sval1sval2sval1: null
+            sval2sval1: null
+        def `test_preserve_table_class`:
+            a: null
+            mean: null
+    __main__: null
+data/tests/test_domain.py:
+    class `DomainTest`:
+        def `test_bool_raises_warning`:
+            y: null
+        def `test_empty`:
+            y: null
+        def `test_conversion`:
+            a: null
+            abc: null
+            cab: null
+            b: null
+            def: null
+            efg: null
+            c: null
+    __main__: null
+data/tests/test_io.py:
+    class `TestTableFilters`:
+        def `test_guess_data_type_continuous`:
+            1: null
+            2: null
+            3: null
+        def `test_guess_data_type_discrete`:
+            1: null
+            2: null
+            a: null
+        def `test_guess_data_type_string`:
+            a: null
+        def `test_guess_data_type_time`:
+            2019-10-10: null
+            2019-10-01: null
+            2019-10-10T12:08:51: null
+            2019-10-01T12:08:51: null
+            2019-10-10 12:08:51: null
+            2019-10-01 12:08:51: null
+            2019-10-10 12:08: null
+            2019-10-01 12:08: null
+        def `test_guess_data_type_values_order`:
+            something1: null
+            something12: null
+            something2: null
+            something20: null
+    class `TestWriters`:
+        def `setUp`:
+            a: null
+            xyz: null
+            b: null
+            c: null
+            d: null
+            foo bar baz: null
+        def `test_write_tab`:
+            .tab: null
+            utf-8: null
+            '
+c\td\ta\tb
+continuous\tstring\tx y z\tcontinuous
+class\tmeta\t\t
+3.0\tfoo\ty\t0.5
+1.0\tbar\tz\t
+7.0\tbaz\t\t1.0625': null
+        def `test_roundtrip_xlsx`:
+            .xlsx: null
+    __main__: null
+data/tests/test_io_base.py:
+    class `InitTestData`:
+        def `setUpClass`:
+            0.1: null
+            0.5: null
+            21.0: null
+            0.2: null
+            2.5: null
+            123.0: null
+            0.0: null
+            a: null
+            b: null
+            c: null
+            d: null
+            red: null
+            2019-10-10: null
+            2019-10-12: null
+            green: null
+            2019-10-11: null
+            m#a: null
+            cC#b: null
+            m#c: null
+            i#e: null
+            f: null
+            aa: null
+            1.0: null
+            2.0: null
+            w: null
+            e: null
+            g: null
+            s: null
+            yes no: null
+            meta: null
+            class: null
+            weight: null
+            i: null
+            no: null
+    class `TestTableHeader`:
+        def `test_rename_variables`:
+            a: null
+            b: null
+            a (1): null
+            a (2): null
+        def `test_get_header_data_1`:
+            a: null
+            b: null
+            c: null
+            d: null
+        def `test_get_header_data_1_flags`:
+            a: null
+            b: null
+            c: null
+            d: null
+            e: null
+            f: null
+            m: null
+            i: null
+        def `test_get_header_data_3`:
+            a: null
+            b: null
+            c: null
+            d: null
+            w: null
+            e: null
+            f: null
+            g: null
+            s: null
+            yes no: null
+            meta: null
+            class: null
+            weight: null
+            i: null
+    class `TestTableBuilder`:
+        def `test_string_column`:
+            s: null
+            red: null
+            green: null
+        def `test_continuous_column`:
+            c: null
+            0.1: null
+            0.2: null
+            0.0: null
+        def `test_continuous_column_raises`:
+            a: null
+            2: null
+            3: null
+            4: null
+            c: null
+        def `test_time_column`:
+            t: null
+            2019-10-10: null
+            2019-10-12: null
+            2019-10-11: null
+        def `test_discrete_column`:
+            d: null
+            green: null
+            red: null
+        def `test_column_parts_discrete_values`:
+            green red: null
+            green: null
+            red: null
+        def `test_unknown_type_column`:
+            0.1: null
+            0.2: null
+            0.0: null
+    class `TestDataTableMixin`:
+        def `test_parse_headers_1`:
+            a: null
+            b: null
+            c: null
+            d: null
+        def `test_parse_headers_1_flags`:
+            m#a: null
+            cC#b: null
+            m#c: null
+            d: null
+            i#e: null
+            f: null
+        def `test_parse_headers_3`:
+            a: null
+            b: null
+            c: null
+            d: null
+            w: null
+            e: null
+            f: null
+            g: null
+            s: null
+            yes no: null
+            meta: null
+            class: null
+            weight: null
+            i: null
+        def `test_adjust_data_width_lengthen`:
+            a: null
+            b: null
+            c: null
+            d: null
+            e: null
+            m: null
+        def `test_adjust_data_width_shorten`:
+            a: null
+            b: null
+            c: null
+            m: null
+        def `test_adjust_data_width_empty`:
+            a: null
+            b: null
+    __main__: null
+data/tests/test_io_util.py:
+    class `TestIoUtil`:
+        def `test_guess_continuous_w_nans`:
+            9: null
+            98: null
+            ?: null
+    __main__: null
+data/tests/test_pandas.py:
+    class `TestPandasCompat`:
+        Missing package 'pandas': null
+        def `test_table_from_frame`:
+            a: null
+            2017-12-19: null
+            b: null
+            1724-12-20: null
+            c: null
+            1: null
+            2: null
+            0: null
+            abaa: null
+            index: null
+        def `test_table_from_frame_keep_ids`:
+            iris: null
+            _oa: null
+            _o: null
+            1: null
+            _o20: null
+            _o30: null
+        def `test_table_to_frame`:
+            iris: null
+            sepal length: null
+            Iris-setosa: null
+        def `test_table_to_frame_object_dtype`:
+            a: null
+        def `test_table_to_frame_nans`:
+            a: null
+            b: null
+        def `test_table_to_frame_metas`:
+            zoo: null
+        def `test_not_orangedf`:
+            iris: null
+        def `test_table_from_frame_date`:
+            2017-12-19: null
+            1724-12-20: null
+        def `test_table_from_frame_time`:
+            00:00:00.25: null
+            20:20:20.30: null
+            1970-01-01 00:00:00.25: null
+            1970-01-01 20:20:20.30: null
+        def `test_table_from_frame_datetime`:
+            2017-12-19 00:00:00.50: null
+            1724-12-20 20:20:20.30: null
+        def `test_table_from_frame_timezones`:
+            2017-12-19 00:00:00: null
+            1724-12-20 20:20:20: null
+            2017-12-19 00:00:00Z: null
+            1724-12-20 20:20:20Z: null
+            2017-12-19 00:00:00+1: null
+            1724-12-20 20:20:20+1: null
+            CET: null
+        def `test_table_from_frame_no_datetime`:
+            object: null
+        def `testa_table_from_frame_string`:
+            a: null
+            b: null
+            c: null
+            d: null
+            e: null
+            f: null
+            s1: null
+            s2: null
+            object: null
+            string: null
+            5: null
+        def `test_time_variable_compatible`:
+            time: null
+        def `test_table_to_frame_on_all_orange_dataset`:
+            Convert all Orange demo dataset. It takes about 5s which is way to slow: null
+            Orange/datasets/: null
+            def `_filename_to_dataset_name`:
+                .: null
+            def `_get_orange_demo_datasets`:
+                .tab: null
+            Failed to process Table('{}'): null
+        def `test_table_from_frames`:
+            brown-selected: null
+        def `test_table_from_frames_not_orange_dataframe`:
+            x1: null
+            x2: null
+            x3: null
+            y: null
+            m1: null
+            m2: null
+        def `test_table_from_frames_same_index`:
+            a: null
+            b: null
+            x1: null
+            x2: null
+            x3: null
+            y: null
+            m1: null
+            m2: null
+            object: null
+            index: null
+            c: null
+    class `TestTablePandas`:
+        def `setUp`:
+            table: null
+            Base class: null
+        def `test_slice`:
+            c2: null
+            d1: null
+        def `test_concat_table`:
+            c2: null
+            d1: null
+        def `test_merge`:
+            c2: null
+            d15: null
+        def `test_new_column`:
+            new: null
+    class `TestDenseTablePandas`:
+        def `setUp`:
+            c1: null
+            c2: null
+            d1: null
+            a: null
+            b: null
+            y: null
+            c3: null
+            d2: null
+            c: null
+            d: null
+            s1: null
+            s2: null
+            a  b  c  d  e     f    g: null
+            ABCDEF: null
+            haha: null
+            hoho: null
+        def `test_contiguous_metas`:
+            1.4.0: null
+            pandas-dev/pandas#39263: null
+        def `test_amend_dimension_mismatch`:
+            Leading dimension mismatch (not 7 == 9): null
+    class `TestSparseTablePandas`:
+        c2: null
+        Continuous Feature 2: null
+        d1: null
+        0: null
+        1: null
+        Discrete Feature 2: null
+        value1: null
+        value2: null
+        Continuous Class: null
+        Discrete Class: null
+        m: null
+        f: null
+    __main__: null
+data/tests/test_sql_mssql.py:
+    class `TestPymssqlBackend`:
+        def `test_connection_error`:
+            host: null
+            port: null
+            database: null
+            DB: null
+        def `test_parse_ex`:
+            Foo: null
+    __main__: null
+data/tests/test_table.py:
+    class `TestTableInit`:
+        def `test_warnings`:
+            x: null
+        def `test_invalid_call_with_kwargs`:
+            iris: null
+        def `test_from_numpy`:
+            abcde: null
+            foo: null
+            abcd: null
+            e: null
+            no: null
+            yes: null
+            s: null
+        def `test_from_numpy_sparse`:
+            abc: null
+        def `test_concatenate_horizontal`:
+            abcdefg: null
+        def `test_concatenate_names`:
+            abcdefg: null
+            tab2: null
+            tab3: null
+        def `test_with_column`:
+            abcdefg: null
+            t: null
+            abcde: null
+        def `test_copy`:
+            x: null
+            y: null
+            z: null
+    class `TestTableLocking`:
+        def `setUpClass`:
+            CI: null
+        def `setUp`:
+            abcdefg: null
+        def `test_unlock_table_derived`:
+            iris: null
+    class `TestTableFilters`:
+        def `setUp`:
+            c1: null
+            c2: null
+            d1: null
+            a: null
+            b: null
+            y: null
+            c3: null
+            d2: null
+            c: null
+            d: null
+            s1: null
+            s2: null
+            a  b  c  d  e     f    g: null
+            ABCDEF: null
+        def `test_row_filters_is_defined`:
+            ab: null
+            abdg: null
+            abcdef: null
+            cdefg: null
+            c1: null
+            abdefg: null
+            c: null
+        def `test_row_filter_no_discrete`:
+            a: null
+        def `test_row_filter_continuous`:
+            adg: null
+            dg: null
+            a: null
+        def `test_row_filter_string`:
+            c: null
+            e: null
+            cde: null
+        def `test_row_stringlist`:
+            bBdDe: null
+            bd: null
+            bDe: null
+            bde: null
+        def `test_row_stringregex`:
+            [bBdDe]: null
+            bd: null
+        def `test_is_defined`:
+            c3: null
+            abcdeg: null
+    class `TableColumnViewTests`:
+        def `setUp`:
+            y: null
+            d: null
+            a: null
+            b: null
+            t: null
+            m: null
+            abc def ghi: null
+            y2: null
+    class `TestTableGetColumn`:
+        def `test_get_column_proper_view`:
+            y: null
+        def `test_get_column_discrete`:
+            d: null
+            a: null
+            b: null
+            c: null
+        def `test_sparse`:
+            y: null
+        def `test_get_column_no_variable`:
+            y3: null
+        def `test_index_by_int`:
+            y: null
+            t: null
+            m: null
+    class `TestTableGetColumnView`:
+        def `test_get_column_view_by_var`:
+            y: null
+            t: null
+            m: null
+        def `test_get_column_view_by_name`:
+            y: null
+            t: null
+            m: null
+            y2: null
+        def `test_get_column_view_by_index`:
+            y2: null
+        def `test_sparse`:
+            ignore: null
+            y: null
+            error: null
+            .*dense copy.*: null
+        def `test_mapped`:
+            ignore: null
+            d: null
+            a: null
+            b: null
+            c: null
+            error: null
+            .*mapped copy.*: null
+        def `test_meta_is_float`:
+            x: null
+            y: null
+            a: null
+            b: null
+    __main__: null
+data/tests/test_util.py:
+    class `TestGetUniqueNames`:
+        def `test_get_unique_names`:
+            foo: null
+            bar: null
+            baz: null
+            baz (3): null
+            qux: null
+            foo (1): null
+            baz (4): null
+            baz (3) (1): null
+            quux: null
+            bar (4): null
+            qux (4): null
+            qux (1): null
+            bar (1): null
+        def `test_get_unique_names_with_domain`:
+            foo: null
+            bar: null
+            baz: null
+            baz (3): null
+            qux: null
+            foo (1): null
+            baz (4): null
+            baz (3) (1): null
+            quux: null
+            bar (4): null
+            qux (4): null
+            qux (1): null
+            bar (1): null
+        def `test_get_unique_names_not_equal`:
+            foo: null
+            bar: null
+            baz: null
+            baz (3): null
+            qux: null
+            foo (1): null
+            baz (4): null
+            baz (3) (1): null
+            quux: null
+            bar (1): null
+        def `test_get_unique_names_duplicated_proposals`:
+            foo: null
+            bar: null
+            baz: null
+            baz (3): null
+            boo: null
+            foo (1): null
+            boo (1): null
+            boo (2): null
+            foo (4): null
+            boo (4): null
+            boo (5): null
+            baz (4): null
+            bong: null
+        def `test_get_unique_names_from_duplicates`:
+            foo: null
+            bar: null
+            baz: null
+            bar (1): null
+            bar (2): null
+            x: null
+            x (1): null
+            x (2): null
+            x (3): null
+            x (2) (1): null
+            x (4): null
+            x (5): null
+            x (2) (2): null
+            iris: null
+            iris (1): null
+            iris (2): null
+            iris (3): null
+            iris (4): null
+            iris (1) (1): null
+            iris (1) (2): null
+            iris (1) (3): null
+        def `test_get_unique_names_domain`:
+            a: null
+            t: null
+            c: null
+            d: null
+            e: null
+            t (1): null
+            t (2): null
+            t (3): null
+            d (1): null
+            d (2): null
+    class `TestSanitizedName`:
+        def `test_sanitized_name`:
+            Foo: null
+            Foo Bar: null
+            Foo_Bar: null
+            0Foo: null
+            _0Foo: null
+            1 Foo Bar: null
+            _1_Foo_Bar: null
+    __main__: null
+data/tests/test_variable.py:
+    class `VariableTest`:
+        def `test_copy_copies_attributes`:
+            x: null
+            a: null
+            b: null
+            c: null
+        def `test_rename`:
+            x: null
+            x2: null
+            _name: null
+        def `varcls_modified`:
+            a: null
+    class `TestVariable`:
+        def `setUpClass`:
+            x: null
+        def `test_name`:
+            Variable(name='x'): null
+        def `test_to_val`:
+            x: null
+            foo: null
+            42: null
+            ?: null
+        def `test_properties`:
+            y: null
+            d: null
+            s: null
+        def `test_properties_as_predicates`:
+            y: null
+            s: null
+        def `test_strange_eq`:
+            a: null
+            somestring: null
+        def `test_eq_with_compute_value`:
+            a: null
+            c: null
+        def `test_hash`:
+            a: null
+            b: null
+        def `test_hash_eq`:
+            a: null
+            b: null
+            b2: null
+            c: null
+        def `test_compute_value_eq_warning`:
+            x: null
+    def `variabletest`:
+        def `decorate`:
+            varcls: null
+    class `TestDiscreteVariable`:
+        def `test_to_val`:
+            F: null
+            M: null
+            Feature 0: null
+            ?: null
+            G: null
+        def `test_make`:
+            a: null
+            F: null
+            M: null
+        def `test_val_from_str`:
+            a: null
+            F: null
+            M: null
+        def `test_val_from_str_add`:
+            a: null
+            F: null
+            M: null
+            N: null
+        def `test_repr`:
+            a: null
+            F: null
+            M: null
+            DiscreteVariable(name='a', values=('F', 'M')): null
+            1234567: null
+            DiscreteVariable(name='a', values=('1', '2', '3', '4', '5', '6', '7')): null
+        def `test_no_nonstringvalues`:
+            foo: null
+            a: null
+            b: null
+            c: null
+        def `test_no_duplicated_values`:
+            foo: null
+            a: null
+            b: null
+            c: null
+        def `test_unpickle`:
+            A: null
+            two: null
+            one: null
+            three: null
+        def `test_mapper_dense`:
+            a: null
+            abc: null
+            dca: null
+            b: null
+            c: null
+        def `test_mapper_sparse`:
+            a: null
+            abc: null
+            dca: null
+            acd: null
+        def `test_mapper_inplace`:
+            a: null
+            abc: null
+            dca: null
+            acd: null
+        def `test_mapper_dim_check`:
+            a: null
+            abc: null
+            dca: null
+        def `test_mapper_from_no_values`:
+            a: null
+            dca: null
+        def `varcls_modified`:
+            A: null
+            B: null
+        def `test_copy_checks_len_values`:
+            gender: null
+            F: null
+            M: null
+            N: null
+            W: null
+        def `test_pickle_backward_compatibility`:
+            default: null
+            ..: null
+            tests: null
+            datasets: null
+            sailing-orange-3-20.pkl: null
+            iris-orange-3-25.pkl: null
+    class `TestContinuousVariable`:
+        def `test_make`:
+            age: null
+        def `test_decimals`:
+            a: null
+            4.6543: null
+            4.2500: null
+            ?: null
+            0.00000: null
+            1e-12: null
+        def `test_more_decimals`:
+            a: null
+            4: null
+            4.12: null
+            4.00: null
+            4.25: null
+            4.1234: null
+        def `test_adjust_decimals`:
+            a: null
+            5: null
+            4.65432: null
+            '  5.12    ': null
+            4.65: null
+            5.00: null
+    class `TestStringVariable`:
+        def `test_val`:
+            a: null
+            ?: null
+            foo: null
+            '"foo"': null
+    class `TestTimeVariable`:
+        2015-10-12 14:13:11.01+0200: null
+        2015-10-12 14:13:11.010000+0200: null
+        2015-10-12T14:13:11.81+0200: null
+        2015-10-12 14:13:11.810000+0200: null
+        2015-10-12 14:13:11.81: null
+        2015-10-12 14:13:11.810000: null
+        2015-10-12T14:13:11.81: null
+        2015-10-12 14:13:11+0200: null
+        2015-10-12T14:13:11+0200: null
+        20151012T141311+0200: null
+        20151012141311+0200: null
+        2015-10-12 14:13:11: null
+        2015-10-12T14:13:11: null
+        2015-10-12 14:13: null
+        2015-10-12 14:13:00: null
+        20151012T141311: null
+        20151012141311: null
+        2015-10-12: null
+        20151012: null
+        2015-285: null
+        2015-10: null
+        2015-10-01: null
+        2015: null
+        2015-01-01: null
+        01:01:01.01: null
+        01:01:01.010000: null
+        010101.01: null
+        01:01:01: null
+        01:01: null
+        01:01:00: null
+        1970-01-01 00:00:00: null
+        1969-12-31 23:59:59: null
+        1969-12-31 23:59:58.9: null
+        1969-12-31 23:59:58.900000: null
+        1900-01-01: null
+        nan: null
+        ?: null
+        1444651991.81: null
+        2015-10-12 12:13:11.810000: null
+        def `test_parse_repr`:
+            time: null
+        def `test_parse_utc`:
+            time: null
+            2015-10-18 22:48:20: null
+            +0200: null
+            2015-10-18 20:48:20: null
+            2015-10-18T22:48:20: null
+            +02:00: null
+        def `test_parse_timestamp`:
+            time: null
+            2016-06-14 23:08:00: null
+        def `test_parse_invalid`:
+            var: null
+            123: null
+        def `test_have_date`:
+            time: null
+            1937-08-02: null
+            16:20: null
+            1970-01-01 16:20:00: null
+        def `test_no_date_no_time`:
+            relative time: null
+            1.6: null
+        def `test_readwrite_timevariable`:
+            '\
+Date,Feature
+time,continuous
+,
+1920-12-12,1.0
+1920-12-13,3.0
+1920-12-14,5.5
+': null
+            Date: null
+            1920-12-12: null
+        def `test_repr_value`:
+            time: null
+            416.3: null
+        def `test_have_date_have_time_in_construct`:
+            time: null
+        def `test_additional_formats`:
+            2021-11-25: null
+            2022-02-07: null
+            25.11.2021: null
+            07.02.2022: null
+            07. 02. 2022: null
+            7.2.2022: null
+            7. 2. 2022: null
+            25.11.21: null
+            07.02.22: null
+            07. 02. 22: null
+            7.2.22: null
+            7. 2. 22: null
+            11/25/2021: null
+            02/07/2022: null
+            2/7/2022: null
+            11/25/21: null
+            02/07/22: null
+            2/7/22: null
+            20211125: null
+            20220207: null
+            2021-11-25 00:00:00: null
+            2022-02-07 10:11:12: null
+            2022-02-07 10:11:12.00: null
+            25.11.2021 00:00:00: null
+            07.02.2022 10:11:12: null
+            07. 02. 2022 10:11:12: null
+            7.2.2022 10:11:12: null
+            7. 2. 2022 10:11:12: null
+            07.02.2022 10:11:12.00: null
+            07. 02. 2022 10:11:12.00: null
+            7.2.2022 10:11:12.00: null
+            7. 2. 2022 10:11:12.00: null
+            25.11.21 00:00:00: null
+            07.02.22 10:11:12: null
+            07. 02. 22 10:11:12: null
+            7.2.22 10:11:12: null
+            7. 2. 22 10:11:12: null
+            07.02.22 10:11:12.00: null
+            07. 02. 22 10:11:12.00: null
+            7.2.22 10:11:12.00: null
+            7. 2. 22 10:11:12.00: null
+            11/25/2021 00:00:00: null
+            02/07/2022 10:11:12: null
+            2/7/2022 10:11:12: null
+            02/07/2022 10:11:12.00: null
+            2/7/2022 10:11:12.00: null
+            11/25/21 00:00:00: null
+            02/07/22 10:11:12: null
+            2/7/22 10:11:12: null
+            02/07/22 10:11:12.00: null
+            2/7/22 10:11:12.00: null
+            20211125000000: null
+            20220207101112: null
+            20220207101112.00: null
+            2022-02-07 10:11: null
+            07.02.2022 10:11: null
+            07. 02. 2022 10:11: null
+            7.2.2022 10:11: null
+            7. 2. 2022 10:11: null
+            07.02.22 10:11: null
+            07. 02. 22 10:11: null
+            7.2.22 10:11: null
+            7. 2. 22 10:11: null
+            02/07/2022 10:11: null
+            2/7/2022 10:11: null
+            02/07/22 10:11: null
+            2/7/22 10:11: null
+            202202071011: null
+            00:00:00: null
+            10:11:12: null
+            10:11:12.00: null
+            000000: null
+            101112: null
+            101112.00: null
+            10:11: null
+            2021: null
+            11-25: null
+            02-07: null
+            25.11.: null
+            07.02.: null
+            07. 02.: null
+            7.2.: null
+            7. 2.: null
+            11/25: null
+            02/07: null
+            2/7: null
+            coerce: null
+    PickleContinuousVariable: null
+    with_name: null
+    Feature 0: null
+    PickleDiscreteVariable: null
+    with_str_value: null
+    F: null
+    M: null
+    PickleStringVariable: null
+    class `VariableTestMakeProxy`:
+        def `test_make_proxy_disc`:
+            abc: null
+        def `test_make_proxy_cont`:
+            abc: null
+        def `test_proxy_has_separate_attributes`:
+            image: null
+            origin: null
+            a: null
+            b: null
+            c: null
+    __main__: null
+distance/tests/test_distance.py:
+    class `CommonTests`:
+        def `test_sparse`:
+            abc: null
+    class `CommonFittedTests`:
+        def `test_mismatching_attributes`:
+            a: null
+            b: null
+            c: null
+            d: null
+    class `CommonNormalizedTests`:
+        def `test_zero_variance`:
+            d: null
+    class `FittedDistanceTest`:
+        def `setUpClass`:
+            c1: null
+            c2: null
+            c3: null
+            d1: null
+            a: null
+            b: null
+            d2: null
+            c: null
+            d: null
+            d3: null
+    class `JaccardDistanceTest`:
+        def `setUp`:
+            abc: null
+        def `test_zero_instances`:
+            abc: null
+    class `TestDataUtilities`:
+        def `test_remove_discrete`:
+            123: null
+            abc: null
+            xy: null
+            t: null
+        def `test_remove_non_binary`:
+            12: null
+            abc: null
+            123: null
+            def: null
+            xy: null
+            t: null
+    __main__: null
+evaluation/tests/test_performance_curves.py:
+    class `TestCurves`:
+        def `test_curves_from_results`:
+            Orange.evaluation.performance_curves.Curves.__init__: null
+        def `test_curves_from_results_nans`:
+            Orange.evaluation.performance_curves.Curves.__init__: null
+misc/tests/test_collections.py:
+    class `TestFrozenDict`:
+        def `test_removed_methods`:
+            a: null
+            b: null
+        def `test_functions_as_dict`:
+            a: null
+            b: null
+            c: null
+    class `TestUtils`:
+        def `test_natural_sorted`:
+            something1: null
+            something20: null
+            something2: null
+            something12: null
+        def `test_natural_sorted_text`:
+            b: null
+            aa: null
+            c: null
+            dd: null
+        def `test_natural_sorted_numbers_str`:
+            1: null
+            20: null
+            2: null
+            12: null
+    class `TestDictMissingConst`:
+        def `test_dict_missing`:
+            <->: null
+            A: null
+            B: null
+    __main__: null
+misc/tests/test_distmatrix.py:
+    class `DistMatrixTest`:
+        def `test_reader_selection`:
+            Orange.misc._distmatrix_xlsx.read_matrix: null
+            _from_dst: null
+            test.dst: null
+            test.xlsx: null
+        def `test_auto_symmetricized_result`:
+            ABC: null
+            ABCD: null
+        def `test_auto_symmetricized_dont_apply`:
+            abc: null
+            def: null
+        def `test_trivial_labels`:
+            abc: null
+            a: null
+            c: null
+            xy: null
+            st: null
+            b: null
+            x: null
+            2: null
+            5: null
+            g: null
+    __main__: null
+misc/tests/test_distmatrix_xlsx.py:
+    xlsx_files: null
+    class `ReadMatrixTest`:
+        def `setUpClass`:
+            distances.xlsx: null
+        def `test_layouts`:
+            Barcelona Belgrade Berlin Brussels: null
+            lower_row_labels: null
+            upper_col_labels: null
+            lower_col_labels: null
+            upper_row_labels: null
+            upper_both_labels: null
+            AERU: null
+            lower_both_labels: null
+            upper_no_labels: null
+            lower_no_labels: null
+            upper_with_diag: null
+            lower_with_diag: null
+            with_nans: null
+            non_square_both: null
+            abcdef: null
+            non_square_row_labels: null
+            non_square_col_labels: null
+            non_square_no_labels: null
+            non_square_off: null
+            abcd??: null
+            ???ABCDE: null
+            just_numbers: null
+        def `test_fast_floats`:
+            numpy.cumsum: null
+            non_square_off: null
+            numbers_upper_left: null
+        def `test_errors`:
+            sheet: Zavihek
+            koala: null
+            E15: null
+            non_square_off_err: null
+            empty: prazen
+            no data: null
+        def `test_active_worksheet`:
+            E15: null
+            sheet: zavihek
+            empty: prazen
+    class `FunctionsTest`:
+        def `setUpClass`:
+            distances.xlsx: null
+        def `test_get_sheet`:
+            lower_row_labels: null
+        def `test_non_empty_cells`:
+            upper_row_labels: null
+            non_square_both: null
+            non_square_off: null
+            a: null
+            E: null
+            no data: null
+            .*empty.*: .*prazen.*
+            numpy.cumsum: null
+            numbers_upper_left: null
+        def `test_get_labels`:
+            a: null
+            b: null
+            c: null
+            bb: null
+            1: null
+            2: null
+            ?: null
+            1.5: null
+        def `test_matrix_from_cells`:
+            3.15: null
+            .*D3.*: null
+            foo: null
+        def `test_write`:
+            .xlsx: null
+            aa: null
+            bb: null
+            cc: null
+            dd: null
+            ee: null
+    __main__: null
+misc/tests/test_embedder_utils.py:
+    class `TestProxies`:
+        def `setUp`:
+            http_proxy: null
+            https_proxy: null
+        def `tearDown`:
+            http_proxy: null
+            https_proxy: null
+        def `test_add_scheme`:
+            http_proxy: null
+            test1.com: null
+            https_proxy: null
+            test2.com: null
+            http://test1.com: null
+            http://: null
+            http://test2.com: null
+            https://: null
+            test1.com/path: null
+            test2.com/path: null
+            http://test1.com/path: null
+            http://test2.com/path: null
+            https://test1.com:123: null
+            https://test2.com:124: null
+        def `test_both_urls`:
+            http_proxy: null
+            http://test1.com:123: null
+            https_proxy: null
+            https://test2.com:124: null
+            http://: null
+            https://: null
+            all://: null
+        def `test_http_only`:
+            http_proxy: null
+            http://test1.com:123: null
+            http://: null
+            https://: null
+        def `test_https_only`:
+            https_proxy: null
+            https://test1.com:123: null
+            https://: null
+            http://: null
+    __main__: null
+misc/tests/test_server_embedder.py:
+    httpx.AsyncClient.post: null
+    '{"embedding": [0, 1]}': null
+    class `TestServerEmbedder`:
+        def `setUp`:
+            test: null
+            https://test.com: null
+            image: null
+            test_var: null
+            test1: null
+            test2: null
+            test3: null
+        def `test_on_non_json_response`:
+            blabla: null
+        def `test_on_json_wrong_key_response`:
+            '{"wrong-key": [0, 1]}': null
+        def `test_persistent_caching`:
+            test: null
+            https://test.com: null
+            image: null
+        def `test_different_models_caches`:
+            different_emb: null
+            https://test.com: null
+            image: null
+            test: null
+        def `test_too_many_examples_for_one_batch`:
+            test_var: null
+            test{i}: null
+        def `test_connection_error`:
+            test_var: null
+            test{i}: null
+        def `test_read_error`:
+            test_var: null
+            test{i}: null
+        def `test_encode_data_instance`:
+            abc: null
+    __main__: null
+modelling/tests/test_catgb.py:
+    class `TestCatGBLearner`:
+        Missing 'catboost' package: null
+        def `setUpClass`:
+            iris: null
+            housing: null
+        def `test_params`:
+            n_estimators: null
+            max_depth: null
+    __main__: null
+modelling/tests/test_gb.py:
+    class `TestGBLearner`:
+        def `setUpClass`:
+            iris: null
+            housing: null
+        def `test_params`:
+            n_estimators: null
+            max_depth: null
+    __main__: null
+modelling/tests/test_xgb.py:
+    class `TestXGB`:
+        Missing 'xgboost' package: null
+        def `setUpClass`:
+            iris: null
+            housing: null
+        def `test_params`:
+            n_estimators: null
+            max_depth: null
+    __main__: null
+preprocess/tests/test_discretize.py:
+    class `TestFixedWidth`:
+        def `test_discretization`:
+            c{i}: null
+            < 0.10: null
+            0.10 - 0.20: null
+            0.20 - 0.30: null
+            ≥ 0.30: null
+            < 0.2: null
+            ≥ 0.2: null
+    class `TestFixedTimeWidth`:
+        def `test_discretization`:
+            t: null
+            1914: null
+            1945: null
+            t2: null
+            t3: null
+            < 1920: null
+            1920 - 1930: null
+            1930 - 1940: null
+            ≥ 1940: null
+            < 1915: null
+            1915 - 1920: null
+            1920 - 1925: null
+            1925 - 1930: null
+            1930 - 1935: null
+            1935 - 1940: null
+            1940 - 1945: null
+            ≥ 1945: null
+            1914-07-28: null
+            1918-11-11: null
+            1915-01-01: null
+            1915-07-01: null
+            1916-01-01: null
+            1916-07-01: null
+            1917-01-01: null
+            1917-07-01: null
+            1918-01-01: null
+            1918-07-01: null
+            < 15 Jan: null
+            15 Jan - Jul: null
+            15 Jul - 16 Jan: null
+            16 Jan - Jul: null
+            16 Jul - 17 Jan: null
+            17 Jan - Jul: null
+            17 Jul - 18 Jan: null
+            18 Jan - Jul: null
+            ≥ 18 Jul: null
+            1914-11-11: null
+            1914-09-01: null
+            1914-11-01: null
+            < Sep: null
+            Sep - Nov: null
+            ≥ Nov: null
+            1914-08-01: null
+            1914-10-01: null
+            < Aug: null
+            Aug - Sep: null
+            Sep - Oct: null
+            Oct - Nov: null
+            1914-06-28 10:45: null
+            1914-07-04 15:25: null
+            1914-06-29: null
+            1914-07-01: null
+            1914-07-03: null
+            < Jun 29: null
+            Jun 29 - Jul 01: null
+            Jul 01 - Jul 03: null
+            ≥ Jul 03: null
+            1914-06-30: null
+            1914-07-02: null
+            1914-07-04: null
+            Jun 29 - Jun 30: null
+            Jun 30 - Jul 01: null
+            Jul 01 - Jul 02: null
+            Jul 02 - Jul 03: null
+            Jul 03 - Jul 04: null
+            ≥ Jul 04: null
+            1914-12-30 22:45: null
+            1915-01-02 15:25: null
+            1914-12-31: null
+            1915-01-02: null
+            < 14 Dec 31: null
+            14 Dec 31 - 15 Jan 01: null
+            15 Jan 01 - Jan 02: null
+            ≥ 15 Jan 02: null
+            1914-06-28 15:25: null
+            1914-06-28 12:00: null
+            1914-06-28 14:00: null
+            < 12:00: null
+            12:00 - 14:00: null
+            ≥ 14:00: null
+            1914-06-28 11:00: null
+            1914-06-28 13:00: null
+            1914-06-28 15:00: null
+            < 11:00: null
+            11:00 - 12:00: null
+            12:00 - 13:00: null
+            13:00 - 14:00: null
+            14:00 - 15:00: null
+            ≥ 15:00: null
+            1914-06-28 22:45: null
+            1914-06-29 03:25: null
+            1914-06-28 23:00: null
+            1914-06-29 00:00: null
+            1914-06-29 01:00: null
+            1914-06-29 02:00: null
+            1914-06-29 03:00: null
+            < Jun 28 23:00: null
+            Jun 28 23:00 - Jun 29 00:00: null
+            Jun 29 00:00 - 01:00: null
+            Jun 29 01:00 - 02:00: null
+            Jun 29 02:00 - 03:00: null
+            ≥ Jun 29 03:00: null
+            1914-06-28 22:43: null
+            1914-06-28 23:01: null
+            1914-06-28 22:50: null
+            1914-06-28 22:55: null
+            < 22:45: null
+            22:45 - 22:50: null
+            22:50 - 22:55: null
+            22:55 - 23:00: null
+            ≥ 23:00: null
+            1914-06-30 23:48: null
+            1914-07-01 00:06: null
+            1914-06-30 23:50: null
+            1914-06-30 23:55: null
+            1914-07-01 00:00: null
+            1914-07-01 00:05: null
+            < Jun 30 23:50: null
+            Jun 30 23:50 - 23:55: null
+            Jun 30 23:55 - Jul 01 00:00: null
+            Jul 01 00:00 - 00:05: null
+            ≥ Jul 01 00:05: null
+            1914-06-29 23:48: null
+            1914-06-30 00:06: null
+            1914-06-29 23:50: null
+            1914-06-29 23:55: null
+            1914-06-30 00:00: null
+            1914-06-30 00:05: null
+            < Jun 29 23:50: null
+            Jun 29 23:50 - 23:55: null
+            Jun 29 23:55 - Jun 30 00:00: null
+            Jun 30 00:00 - 00:05: null
+            ≥ Jun 30 00:05: null
+            1914-06-29 23:48:05: null
+            1914-06-29 23:51:59: null
+            1914-06-29 23:49: null
+            1914-06-29 23:51: null
+            < 23:49: null
+            23:49 - 23:50: null
+            23:50 - 23:51: null
+            ≥ 23:51: null
+            1914-06-29 23:48:05.123: null
+            1914-06-29 23:48:33.684: null
+            1914-06-29 23:48:10: null
+            1914-06-29 23:48:20: null
+            1914-06-29 23:48:30: null
+            < 23:48:10: null
+            23:48:10 - 23:48:20: null
+            23:48:20 - 23:48:30: null
+            ≥ 23:48:30: null
+            1914-12-31 23:59:58.1: null
+            1915-01-01 00:00:01.8: null
+            1914-12-31 23:59:59: null
+            1915-01-01 00:00:00: null
+            1915-01-01 00:00:01: null
+            < 23:59:59: null
+            23:59:59 - 00:00:00: null
+            00:00:00 - 00:00:01: null
+            ≥ 00:00:01: null
+    class `TestBinningDiscretizer`:
+        def `test_no_data`:
+            y: null
+        def `test_call`:
+            Orange.preprocess.discretize.time_binnings: null
+            Orange.preprocess.discretize.decimal_binnings: null
+            Orange.preprocess.discretize.Binning._create_binned_var: null
+            y: null
+            t: null
+        def `test_binning_selection`:
+            y: null
+            t{x}: null
+            < t1: null
+            t1 - t2: null
+            ≥ t2: null
+            t2 - t3: null
+            t3 - t4: null
+            ≥ t4: null
+    class `TestTimeBinning`:
+        def `test_binning`:
+            def `tr1`:
+                Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec: null
+            10 years: 10 let
+            1970: null
+            1980: null
+            1990: null
+            5 years: 5 let
+            1975: null
+            1985: null
+            2 years: 2 leti
+            1974: null
+            1976: null
+            1978: null
+            1982: null
+            1984: null
+            1986: null
+            1988: null
+            1 year: 1 leto
+            1977: null
+            1979: null
+            1981: null
+            1983: null
+            1987: null
+            1989: null
+            6 months: 6 mesecev
+            75 Jan: null
+            Jul: null
+            76 Jan: null
+            77 Jan: null
+            78 Jan: null
+            79 Jan: null
+            80 Jan: null
+            81 Jan: null
+            82 Jan: null
+            83 Jan: null
+            84 Jan: null
+            85 Jan: null
+            86 Jan: null
+            87 Jan: null
+            88 Jan: null
+            89 Jan: null
+            3 months: 3 meseci
+            75 Apr: null
+            Oct: null
+            Apr: null
+            2 months: 2 meseca
+            75 Mar: null
+            May: null
+            Sep: null
+            Nov: null
+            Mar: null
+            1 month: 1 mesec
+            Jun: null
+            Aug: null
+            Dec: null
+            Feb: null
+            75 Dec: null
+            2 weeks: 2 tedna
+            75 Dec 03: null
+            17: null
+            31: null
+            76 Jan 14: null
+            1 week: 1 teden
+            10: null
+            24: null
+            76 Jan 07: null
+            1 day: 1 dan
+            75 Dec 02: null
+            03: null
+            04: null
+            05: null
+            06: null
+            07: null
+            08: null
+            09: null
+            11: null
+            12: null
+            13: null
+            14: null
+            15: null
+            16: null
+            18: null
+            19: null
+            20: null
+            21: null
+            22: null
+            23: null
+            25: null
+            26: null
+            27: null
+            28: null
+            29: null
+            30: null
+            76 Jan 01: null
+            02: null
+            75 Dec 25: null
+            12 hours: 12 ur
+            75 Dec 25 00:00: null
+            12:00: null
+            26 00:00: null
+            27 00:00: null
+            28 00:00: null
+            29 00:00: null
+            30 00:00: null
+            31 00:00: null
+            76 Jan 01 00:00: null
+            02 00:00: null
+            03 00:00: null
+            6 hours: 6 ur
+            06:00: null
+            18:00: null
+            75 Dec 29: null
+            75 Dec 29 00:00: null
+            3 hours: 3 ure
+            03:00: null
+            09:00: null
+            15:00: null
+            21:00: null
+            75 Dec 31: null
+            75 Dec 31 00:00: null
+            2 hours: 2 uri
+            02:00: null
+            04:00: null
+            08:00: null
+            10:00: null
+            14:00: null
+            16:00: null
+            20:00: null
+            22:00: null
+            1 hour: 1 ura
+            01:00: null
+            05:00: null
+            07:00: null
+            11:00: null
+            13:00: null
+            17:00: null
+            19:00: null
+            23:00: null
+            75 Dec 31 06:00: null
+            30 minutes: 30 minut
+            Dec 31 06:00: null
+            06:30: null
+            07:30: null
+            08:30: null
+            09:30: null
+            10:30: null
+            11:30: null
+            12:30: null
+            13:30: null
+            14:30: null
+            15:30: null
+            16:30: null
+            17:30: null
+            18:30: null
+            19:30: null
+            20:30: null
+            21:30: null
+            22:30: null
+            23:30: null
+            Jan 01 00:00: null
+            00:30: null
+            75 Dec 31 21:00: null
+            75 Dec 31 22:00: null
+            75 Dec 31 23:00: null
+            Dec 31 23:00: null
+            01:30: null
+            02:30: null
+            15 minutes: 15 minut
+            23:15: null
+            23:45: null
+            00:15: null
+            00:45: null
+            01:15: null
+            01:45: null
+            02:15: null
+            10 minutes: 10 minut
+            23:10: null
+            23:20: null
+            23:40: null
+            23:50: null
+            00:10: null
+            00:20: null
+            00:40: null
+            00:50: null
+            01:10: null
+            01:20: null
+            01:40: null
+            01:50: null
+            02:10: null
+            5 minutes: 5 minut
+            23:05: null
+            23:25: null
+            23:35: null
+            23:55: null
+            00:05: null
+            00:25: null
+            00:35: null
+            00:55: null
+            01:05: null
+            01:25: null
+            01:35: null
+            01:55: null
+            02:05: null
+            Jun 09 00:00: null
+            10 00:00: null
+            Jun 09 06:00: null
+            Jun 09 09:00: null
+            Jun 09 10:00: null
+            10:15: null
+            10:45: null
+            11:15: null
+            11:45: null
+            12:15: null
+            12:45: null
+            13:15: null
+            10:10: null
+            10:20: null
+            10:40: null
+            10:50: null
+            11:10: null
+            11:20: null
+            11:40: null
+            11:50: null
+            12:10: null
+            12:20: null
+            12:40: null
+            12:50: null
+            13:10: null
+            13:20: null
+            10:05: null
+            10:25: null
+            10:35: null
+            10:55: null
+            11:05: null
+            11:25: null
+            11:35: null
+            11:55: null
+            12:05: null
+            12:25: null
+            12:35: null
+            12:55: null
+            13:05: null
+            1 minute: 1 minuta
+            10:01: null
+            10:02: null
+            10:03: null
+            10:04: null
+            10:06: null
+            10:07: null
+            10:08: null
+            10:09: null
+            10:11: null
+            10:12: null
+            10:13: null
+            10:14: null
+            10:16: null
+            10:17: null
+            10:18: null
+            10:19: null
+            10:21: null
+            10:22: null
+            10:23: null
+            10:24: null
+            10:26: null
+            10:27: null
+            10:28: null
+            10:29: null
+            10:31: null
+            10:32: null
+            10:33: null
+            10:34: null
+            10:36: null
+            10:37: null
+            10:38: null
+            10:39: null
+            10:41: null
+            10:42: null
+            10:43: null
+            10:44: null
+            10:46: null
+            10:47: null
+            10:48: null
+            10:49: null
+            30 seconds: 30 sekund
+            10:00:00: null
+            10:00:30: null
+            10:01:00: null
+            10:01:30: null
+            10:02:00: null
+            10:02:30: null
+            10:03:00: null
+            10:03:30: null
+            10:04:00: null
+            10:04:30: null
+            10:05:00: null
+            10:05:30: null
+            10:06:00: null
+            10:06:30: null
+            10:07:00: null
+            10:07:30: null
+            10:08:00: null
+            10:08:30: null
+            10:09:00: null
+            10:09:30: null
+            10:10:00: null
+            10:10:30: null
+            10:11:00: null
+            10:11:30: null
+            10:12:00: null
+            10:12:30: null
+            10:13:00: null
+            10:13:30: null
+            10:14:00: null
+            10:14:30: null
+            10:15:00: null
+            10:15:30: null
+            10:16:00: null
+            10:16:30: null
+            10:17:00: null
+            10:17:30: null
+            10:18:00: null
+            10:18:30: null
+            10:19:00: null
+            10:19:30: null
+            10:20:00: null
+            10:20:30: null
+            15 seconds: 15 sekund
+            10:12:45: null
+            10:13:15: null
+            10:13:45: null
+            10:14:15: null
+            10:14:45: null
+            10:15:15: null
+            10:15:45: null
+            10:16:15: null
+            10:16:45: null
+            10:17:15: null
+            10:17:45: null
+            10:18:15: null
+            10 seconds: 10 sekund
+            10:12:40: null
+            10:12:50: null
+            10:13:10: null
+            10:13:20: null
+            10:13:40: null
+            10:13:50: null
+            10:14:10: null
+            10:14:20: null
+            10:14:40: null
+            10:14:50: null
+            10:15:10: null
+            10:15:20: null
+            10:15:40: null
+            10:15:50: null
+            10:16:10: null
+            10:16:20: null
+            10:16:40: null
+            10:16:50: null
+            10:17:10: null
+            10:17:20: null
+            10:17:40: null
+            10:17:50: null
+            10:18:10: null
+            10:18:20: null
+            5 seconds: 5 sekund
+            10:12:35: null
+            10:12:55: null
+            10:13:05: null
+            1 second: 1 sekunda
+            10:12:33: null
+            10:12:34: null
+            10:12:36: null
+            10:12:37: null
+            10:12:38: null
+            10:12:39: null
+            10:12:41: null
+            10:12:42: null
+            10:12:43: null
+            10:12:44: null
+            10:12:46: null
+            10:12:47: null
+            10:12:48: null
+            10:12:49: null
+            10:12:51: null
+            10:12:52: null
+            10:12:53: null
+            10:12:54: null
+            10:12:56: null
+            10:12:57: null
+            10:12:58: null
+            10:12:59: null
+            10:13:01: null
+            10:13:02: null
+            10:13:03: null
+            10:13:04: null
+            10:13:06: null
+            10:13:07: null
+            10:13:08: null
+            10:13:09: null
+            10:13:11: null
+            10:13:12: null
+            10:13:13: null
+            50 years: 50 let
+            1950: null
+            2000: null
+            2050: null
+            25 years: 25 let
+            2025: null
+            2010: null
+            2020: null
+            1995: null
+            2005: null
+            2015: null
+            1972: null
+            1992: null
+            1994: null
+            1996: null
+            1998: null
+            2002: null
+            2004: null
+            2006: null
+            2008: null
+            2012: null
+            1973: null
+            1991: null
+            1993: null
+            1997: null
+            1999: null
+            2001: null
+            2003: null
+            2007: null
+            2009: null
+            2011: null
+    class `TestBinDefinition`:
+        def `test_labels`:
+            1: null
+            2: null
+            3.14: null
+            %.3f: null
+            1.000: null
+            2.000: null
+            3.140: null
+            b{x:g}: null
+            b1: null
+            b2: null
+            b3.14: null
+            abc: null
+        def `test_width_label`:
+            3: null
+            3.14: null
+    class `TestDiscretizer`:
+        def `test_equality`:
+            x: null
+            y: null
+    __main__: null
+preprocess/tests/test_fss.py:
+    class `SelectBestFeaturesTest`:
+        def `test_no_nice_features`:
+            x: null
+            -inf: null
+            inf: null
+    __main__: null
+preprocess/tests/test_impute.py:
+    class `TestReplaceUnknowns`:
+        def `test_equality`:
+            x: null
+            y: null
+    class `TestReplaceUnknownsRandom`:
+        def `test_equality`:
+            x: null
+            abc: null
+            y: null
+    class `TestFixedValuesByType`:
+        def `setUp`:
+            d: null
+            abc: null
+            c: null
+            t: null
+            s: null
+            foo: null
+        def `test_all_defined`:
+            foo: null
+        def `test_with_default`:
+            foo: null
+            bar: null
+    class `TestReplaceUnknownsModel`:
+        def `test_eq`:
+            iris: null
+    __main__: null
+preprocess/tests/test_transformation.py:
+    class `TestTransformEquality`:
+        def `setUp`:
+            d1: null
+            abc: null
+            d2: null
+        def `test_mapping`:
+            a: null
+            1: null
+            b: null
+            2: null
+            c: null
+            3: null
+            nan: null
+            f: null
+            k: null
+            j: null
+    class `TestIndicator`:
+        def `test_nan`:
+            d: null
+            abcde: null
+    __main__: null
+regression/tests/test_catgb_reg.py:
+    class `TestCatGBRegressor`:
+        Missing 'catboost' package: null
+        def `setUpClass`:
+            housing: null
+        def `test_set_params`:
+            n_estimators: null
+            max_depth: null
+    __main__: null
+regression/tests/test_curvefit.py:
+    class `TestCreateLambda`:
+        def `test_create_lambda_simple`:
+            a + b: null
+            a: null
+            b: null
+        def `test_create_lambda_var`:
+            var + a + b: null
+            var: null
+            a: null
+            b: null
+        def `test_create_lambda_fun`:
+            power(a, 2): null
+            power: null
+            a: null
+        def `test_create_lambda_var_fun`:
+            var1 + power(a, 2) + power(a, 2): null
+            var1: null
+            var2: null
+            power: null
+            a: null
+        def `test_create_lambda_x`:
+            var1 + x: null
+            var1: null
+            var2: null
+            x: null
+        def `test_create_lambda_ast`:
+            a + b: null
+            eval: null
+            a: null
+            b: null
+        def `test_create_lambda`:
+            a * var1 + b * exp(var2 * power(pi, 0)): null
+            var1: null
+            var2: null
+            var3: null
+            exp: null
+            power: null
+            pi: null
+            a: null
+            b: null
+    class `TestCurveFitLearner`:
+        def `setUpClass`:
+            housing: null
+        def `test_init_str`:
+            a + b: null
+        def `test_init_ast`:
+            a + b: null
+            eval: null
+        def `test_fit`:
+            CRIM: null
+        def `test_fit_no_params`:
+            CRIM: null
+        def `test_predict`:
+            CRIM: null
+        def `test_predict_constant`:
+            CRIM: null
+        def `test_coefficients`:
+            a: null
+            b: null
+            c: null
+            LSTAT: null
+        def `test_inadequate_data`:
+            iris: null
+            sepal length: null
+        def `test_missing_values`:
+            CRIM: null
+        def `test_cv`:
+            CRIM: null
+        def `test_cv_preprocess`:
+            a: null
+            CRIM: null
+        def `test_predict_single_instance`:
+            CRIM: null
+        def `test_predict_table`:
+            CRIM: null
+        def `test_predict_numpy`:
+            CRIM: null
+        def `test_predict_sparse`:
+            CRIM: null
+        def `test_can_copy_str`:
+            a * exp(-b * CRIM) + c: null
+            exp: null
+        def `test_can_copy_callable`:
+            CRIM: null
+        def `test_can_copy_with_imputer`:
+            a * exp(-b * CRIM) + c: null
+            exp: null
+        def `test_can_pickle_str`:
+            a * exp(-b * CRIM) + c: null
+            exp: null
+        def `test_can_pickle_callable`:
+            CRIM: null
+    __main__: null
+regression/tests/test_gb_reg.py:
+    class `TestGBRegressor`:
+        def `setUpClass`:
+            housing: null
+        def `test_set_params`:
+            n_estimators: null
+            max_depth: null
+    __main__: null
+regression/tests/test_xgb_reg.py:
+    class `TestXGBReg`:
+        Missing 'xgboost' package: null
+        def `setUpClass`:
+            housing: null
+        def `test_set_params`:
+            n_estimators: null
+            max_depth: null
+        def `test_scorer`:
+            Missing 'xgboost' package: null
+    __main__: null
+tests/test_ada_boost.py:
+    class `TestSklAdaBoostLearner`:
+        def `setUpClass`:
+            iris: null
+            housing: null
+tests/test_base.py:
+    class `TestLearner`:
+        def `test_uses_default_preprocessors_unless_custom_pps_specified`:
+            'Learner should use default preprocessors, unless preprocessors ': null
+            were specified in init: null
+        def `test_overrides_custom_preprocessors`:
+            'Learner should override default preprocessors when specified in ': null
+            constructor: null
+        def `test_use_default_preprocessors_property`:
+            'Learner did not properly insert custom preprocessor into ': null
+            preprocessor list: null
+            Custom preprocessor was inserted in incorrect order: null
+        def `test_preprocessors_can_be_passed_in_as_non_iterable`:
+            'Preprocessors should be able to be passed in as single object ': null
+            as well as an iterable object: null
+        def `test_preprocessors_can_be_passed_in_as_generator`:
+            'Preprocessors should be able to be passed in as single object ': null
+            as well as an iterable object: null
+        def `test_callback`:
+            iris: null
+    class `TestSklLearner`:
+        def `test_linreg`:
+            'Either LinearRegression no longer supports weighted tables or ': null
+            SklLearner.supports_weights is out-of-date.: null
+        def `test_callback`:
+            iris: null
+    __main__: null
+tests/test_basic_stats.py:
+    class `TestDomainBasicStats`:
+        def `setUp`:
+            zoo: null
+tests/test_basket_reader.py:
+    def `with_file`:
+        def `fle_decorator`:
+            def `decorated`:
+                utf-8: null
+    class `TestBasketReader`:
+        def `test_read_variable_is_value_syntax`:
+            a=1,b=2,c=3: null
+            a: null
+            b: null
+            c: null
+        def `test_read_variable_only_syntax`:
+            a,b,c,d,e: null
+        def `test_handles_spaces_between_variables`:
+            a=1, b=2, c=3: null
+        def `test_variables_can_be_listed_in_any_order`:
+            a,b\nc,b,a: null
+        def `test_handles_unicode`:
+            č,š,ž: null
+        def `test_handles_quote`:
+            a=4,"x"=1.0,"y"=2.0,b=5\n"x"=1.0: null
+        def `test_sums_duplicates`:
+            a,a,b\nb=2,b=3,c: null
+        def `test_data_name`:
+            datasets/iris_basket.basket: null
+            iris_basket: null
+    __main__: null
+tests/test_classification.py:
+    def `all_learners`:
+        Orange.classification.: null
+        _: null
+        base: null
+    class `ModelTest`:
+        def `test_predict_single_instance`:
+            titanic: null
+        def `test_prediction_dimensions`:
+            abcde: null
+            y: null
+            a: null
+            b: null
+            in test for type '{type(inp)}': null
+        def `test_learner_adequacy`:
+            housing: null
+        def `test_value_from_probs`:
+            i: null
+            c: null
+            0123: null
+        def `test_probs_from_value`:
+            v: null
+            c: null
+            12: null
+            i: null
+            0123: null
+        def `test_incompatible_domain`:
+            iris: null
+            titanic: null
+        def `test_result_shape`:
+            iris: null
+        def `test_result_shape_numpy`:
+            iris: null
+            a: null
+            b: null
+        def `test_predict_proba`:
+            heart_disease: null
+    class `ExpandProbabilitiesTest`:
+        def `prepareTable`:
+            Feature %i: null
+            Class %i: null
+            01: null
+    class `SklTest`:
+        def `test_multinomial`:
+            titanic: null
+        def `test_nan_columns`:
+            iris: null
+    class `ClassfierListInputTest`:
+        def `test_discrete`:
+            titanic: null
+            crew: null
+            adult: null
+            male: null
+        def `test_continuous`:
+            iris: null
+    class `UnknownValuesInPrediction`:
+        def `test_unknown`:
+            iris: null
+        def `test_missing_class`:
+            datasets/adult_sample_missing: null
+            nu: null
+    class `LearnerAccessibility`:
+        def `setUp`:
+            ignore: null
+            .*: null
+        def `test_all_learners_accessible_in_Orange_classification_namespace`:
+            %s is not visible in Orange.classification: null
+            ' namespace': null
+        def `test_all_models_work_after_unpickling`:
+            iris: null
+            titanic: null
+            %s does not return same values when unpickled %s: null
+        def `test_all_models_work_after_unpickling_pca`:
+            iris: null
+            titanic: null
+            %s does not return same values when unpickled %s: null
+        def `test_adequacy_all_learners`:
+            housing: null
+        def `test_adequacy_all_learners_multiclass`:
+            datasets/test8.tab: null
+    __main__: null
+tests/test_clustering_dbscan.py:
+    class `TestDBSCAN`:
+        def `setUp`:
+            iris: null
+        def `test_dbscan_parameters`:
+            euclidean: null
+            auto: null
+tests/test_clustering_hierarchical.py:
+    class `TestHierarchical`:
+        def `setUpClass`:
+            Ann: null
+            Bob: null
+            Curt: null
+            Danny: null
+            Eve: null
+            Fred: null
+            Greg: null
+            Hue: null
+            Ivy: null
+            Jon: null
+            lower: null
+        def `test_form`:
+            lower: null
+            upper: null
+        def `test_pre_post_order`:
+            A: null
+            B: null
+            C: null
+        def `test_table_clustering`:
+            single: null
+    class `TestTree`:
+        def `test_tree`:
+            Tree(value=0, branches=()): null
+tests/test_clustering_kmeans.py:
+    class `TestKMeans`:
+        def `setUp`:
+            iris: null
+        def `test_kmeans_parameters`:
+            random: null
+        def `test_model_data_table_domain`:
+            a: null
+            housing: null
+tests/test_clustering_louvain.py:
+    class `TestLouvain`:
+        def `setUp`:
+            iris: null
+        def `test_louvain_parameters`:
+            l2: null
+        def `test_graph`:
+            l2: null
+tests/test_contingency.py:
+    class `TestDiscrete`:
+        def `setUpClass`:
+            zoo: null
+            datasets/test9.tab: null
+        def `test_discrete`:
+            amphibian: null
+            predator: null
+            fish: null
+        def `test_discrete_missing`:
+            zoo: null
+            nan: null
+            amphibian: null
+            predator: null
+            fish: null
+        def `test_array_with_unknowns`:
+            zoo: null
+            nan: null
+            predator: null
+        def `test_discrete_with_fallback`:
+            zoo: null
+        def `test_continuous`:
+            iris: null
+            sepal width: null
+            Iris-setosa: null
+            Iris-virginica: null
+        def `test_continuous_missing`:
+            iris: null
+            nan: null
+            sepal width: null
+            Iris-setosa: null
+            Iris-virginica: null
+        def `test_continuous_array_with_unknowns`:
+            iris: null
+            nan: null
+            sepal width: null
+        def `test_mixedtype_metas`:
+            zoo: null
+            1: null
+            nan: null
+        def `_construct_sparse`:
+            d%i: null
+            abc: null
+            c%i: null
+            y: null
+        def `test_sparse`:
+            b: null
+            c3: null
+        def `test_get_contingency`:
+            b: null
+            c4: null
+        def `test_get_contingencies`:
+            b: null
+        def `test_compute_contingency_invalid`:
+            X: null
+            C: null
+            C{}: null
+tests/test_continuize.py:
+    class `TestDomainContinuizer`:
+        def `setUp`:
+            datasets/test4: null
+        def `test_default`:
+            c1: null
+            c2: null
+            d2=a: null
+            d2=b: null
+            d3=a: null
+            d3=b: null
+            d3=c: null
+            a: null
+            b: null
+            c: null
+        def `test_continuous_transform_class`:
+            c1: null
+            c2: null
+            d2=a: null
+            d2=b: null
+            d3=a: null
+            d3=b: null
+            d3=c: null
+        def `test_multi_indicators`:
+            c1: null
+            c2: null
+            d2=a: null
+            d2=b: null
+            d3=a: null
+            d3=b: null
+            d3=c: null
+            a: null
+            b: null
+            c: null
+        def `test_multi_lowest_base`:
+            c1: null
+            c2: null
+            d2=b: null
+            d3=b: null
+            d3=c: null
+            a: null
+            b: null
+            c: null
+        def `test_multi_ignore`:
+            c1: null
+            c2: null
+        def `test_multi_ignore_class`:
+            c1: null
+            c2: null
+            d2=b: null
+        def `test_multi_ignore_multi`:
+            c1: null
+            c2: null
+            d2=b: null
+            cl1: null
+        def `test_as_ordinal`:
+            c1: null
+            c2: null
+            d2: null
+            d3: null
+            cl1: null
+            a: null
+            b: null
+            c: null
+        def `test_as_ordinal_class`:
+            c1: null
+            c2: null
+            d2: null
+            d3: null
+            cl1: null
+        def `test_as_normalized_ordinal`:
+            c1: null
+            c2: null
+            d2: null
+            d3: null
+            cl1: null
+            a: null
+            b: null
+            c: null
+tests/test_cur.py:
+    class `TestCUR`:
+        def `setUpClass`:
+            datasets/ionosphere.tab: null
+        def `__reconstruction_test_helper`:
+            fro: null
+tests/test_data_util.py:
+    class `TestSharedComputeValue`:
+        def `test_compat_compute_value`:
+            iris: null
+        def `test_with_row_indices`:
+            iris: null
+            cv: null
+        def `test_single_call`:
+            iris: null
+        def `test_eq_hash`:
+            x: null
+            y: null
+tests/test_datasets.py:
+    class `TestDatasets`:
+        def `test_access`:
+            location: null
+            iris: null
+        def `test_filter`:
+            features: null
+            continuous: null
+            location: null
+        def `test_have_all`:
+            ../datasets: null
+            .tab: null
+        def `test_datasets_info_features`:
+            location: null
+            http: null
+            rows: null
+            missing: null
+            features: null
+            meta: null
+            discrete: null
+            continuous: null
+            target: null
+            type: null
+            values: null
+tests/test_discretize.py:
+    class `TestEntropyMDL`:
+        def `test_entropy_constant`:
+            v1: null
+            c1: null
+            1: null
+    class `TestDiscretizer`:
+        def `setUp`:
+            x: null
+        def `test_create_discretized_var_formatting`:
+            < 1: null
+            1 - 2: null
+            2 - 3: null
+            ≥ 3: null
+            < 10: null
+            ≥ 10: null
+            < 10.123: null
+            ≥ 10.123: null
+            < 5: null
+            5 - 10.25: null
+            ≥ 10.25: null
+            5 - 10.1234: null
+            ≥ 10.1234: null
+        def `test_transform`:
+            iris: null
+        def `test_remove_constant`:
+            iris: null
+        def `test_keep_constant`:
+            iris: null
+        def `test_discretize_class`:
+            iris: null
+        def `test_discretize_metas`:
+            iris: null
+    class `TestDiscretizeTable`:
+        def `test_fixed`:
+            Feature 2: null
+        def `test_leave_discrete`:
+            a: null
+            MF: null
+            b: null
+            c: null
+            AB: null
+            d: null
+    class `TestInstanceConversion`:
+        def `test_single_instance`:
+            iris: null
+            Iris-virginica: null
+tests/test_distances.py:
+    class `TestDistMatrix`:
+        def `setUpClass`:
+            iris: null
+        def `test_from_file`:
+            '3 axis=0 asymmetric col_labels row_labels
+                    ann	bert	chad
+                    danny	0.12	3.45	6.78
+                    eve	9.01	2.34	5.67
+                    frank	8.90	1.23	4.56': null
+            ann: null
+            bert: null
+            chad: null
+            danny: null
+            eve: null
+            frank: null
+            '3 axis=1 row_labels
+                    danny	0.12	3.45	6.78
+                    eve 	9.01	2.34	5.67
+                    frank	8.90': null
+            '3 axis=1 symmetric
+                    0.12	3.45	6.78
+                    9.01	2.34	5.67
+                    8.90': null
+            '3 row_labels
+                    starič	0.12	3.45	6.78
+                    aleš	9.01	2.34	5.67
+                    anže	8.90': null
+            utf-8: null
+            starič: null
+            aleš: null
+            anže: null
+            empty file: prazna datoteka
+            axis=1\n1\t3\n4: null
+            distance file must begin with dimension: datoteka se mora začeti z dimenzijo matrike
+            3 col_labels\na\tb\n1\n\2\n3: null
+            mismatching number of column labels, 2 != 3: napačno število oznak stolpcev, 2 != 3
+            3 col_labels\na\tb\tc\td\n1\n\2\n3: null
+            mismatching number of column labels, 4 != 3: napačno število oznak stolpcev, 4 != 3
+            2\n  1\t2\t3\n  5: null
+            too many columns in matrix row 1: preveč stolpcev v vrstici 1
+            2 row_labels\na\t1\t2\t3\nb\t5: null
+            too many columns in matrix row 'a': preveč stolpcev v vrstici 'a'
+            2 noflag\n  1\t2\t3\n  5: null
+            invalid flag 'noflag': null
+            2 noflag=5\n  1\t2\t3\n  5: null
+            invalid flag 'noflag=5': null
+            2\n1\n2\n3: null
+            too many rows: preveč vrstic
+            2\n1\nasd: null
+            invalid element at row 2, column 1: napačna vrednost v vrstici 2, stolpcu 1
+            2 row_labels\na\t1\nb\tasd: null
+            invalid element at row 'b', column 1: napačna vrednost v vrstici 'b', stolpcu 1
+            2 col_labels row_labels\nd\te\na\t1\nb\tasd: null
+            invalid element at row 'b', column 'd': napačna vrednost v vrstici 'b', stolpcu 'd'
+            2 col_labels\nd\te\n1\nasd: null
+            invalid element at row 2, column 'd': napačna vrednost v vrstici 2, stolpcu 'd'
+        def `test_save`:
+            '3 axis=1 row_labels
+                    danny	0.12	3.45	6.78
+                    eve 	9.01	2.34	5.67
+                    frank	8.90': null
+            danny: null
+            eve: null
+            frank: null
+            '3 axis=0 asymmetric col_labels row_labels
+                             ann	bert	chad
+                    danny	0.12	3.45	6.78
+                      eve	9.01	2.34	5.67
+                    frank	8.90	1.23	4.56': null
+            ann: null
+            bert: null
+            chad: null
+    class `TestEuclidean`:
+        def `setUpClass`:
+            iris: null
+    class `TestManhattan`:
+        def `setUpClass`:
+            iris: null
+    class `TestCosine`:
+        def `setUpClass`:
+            iris: null
+    class `TestJaccard`:
+        def `setUpClass`:
+            titanic: null
+    class `TestSpearmanR`:
+        def `setUpClass`:
+            datasets/breast-cancer-wisconsin.tab: null
+    class `TestSpearmanRAbsolute`:
+        def `setUpClass`:
+            datasets/breast-cancer-wisconsin.tab: null
+    class `TestPearsonR`:
+        def `setUpClass`:
+            datasets/breast-cancer-wisconsin.tab: null
+    class `TestPearsonRAbsolute`:
+        def `setUpClass`:
+            datasets/breast-cancer-wisconsin.tab: null
+    class `TestMahalanobis`:
+        def `test_correctness`:
+            mahalanobis: null
+        def `test_iris`:
+            iris: null
+        def `test_dimensions`:
+            iris: null
+    class `TestBhattacharyya`:
+        def `test_dense_array`:
+            iris: null
+    class `TestDistances`:
+        def `setUpClass`:
+            datasets/test5.tab: null
+        def `test_preprocess`:
+            c: null
+            d: null
+            a: null
+            b: null
+            cls: null
+            e: null
+            f: null
+            m: null
+            m1: null
+            m2: null
+        def `test_distance_to_instance`:
+            iris: null
+    __main__: null
+tests/test_distribution.py:
+    class `TestDiscreteDistribution`:
+        def `setUp`:
+            rgb: null
+            r: null
+            g: null
+            b: null
+            a: null
+            num: null
+            1: null
+            2: null
+            3: null
+        def `test_from_table`:
+            zoo: null
+            type: null
+        def `test_construction`:
+            zoo: null
+            type: null
+        def `test_fallback`:
+            zoo: null
+            type: null
+        def `test_fallback_with_weights_and_nan`:
+            zoo: null
+            type: null
+        def `test_pickle`:
+            zoo: null
+        def `test_deepcopy`:
+            zoo: null
+        def `test_equality`:
+            zoo: null
+        def `test_indexing`:
+            zoo: null
+            amphibian: null
+            mammal: null
+        def `test_hash`:
+            zoo: null
+            type: null
+        def `test_add`:
+            zoo: null
+            type: null
+        def `test_normalize`:
+            zoo: null
+            type: null
+        def `test_modus`:
+            zoo: null
+            type: null
+            mammal: null
+        def `test_array_with_unknowns`:
+            zoo: null
+            type: null
+    class `TestContinuousDistribution`:
+        def `setUpClass`:
+            iris: null
+            n1: null
+            n2: null
+        def `test_from_table`:
+            petal length: null
+        def `test_construction`:
+            petal length: null
+        def `test_hash`:
+            petal length: null
+        def `test_normalize`:
+            petal length: null
+        def `test_random`:
+            petal length: null
+    class `TestClassDistribution`:
+        def `test_class_distribution`:
+            zoo: null
+            type: null
+        def `test_multiple_target_variables`:
+            n1: null
+            c1: null
+            r: null
+            g: null
+            b: null
+            a: null
+            c2: null
+            c3: null
+    class `TestGetDistribution`:
+        def `test_get_distribution`:
+            iris: null
+    class `TestDomainDistribution`:
+        def `test_get_distributions`:
+            iris: null
+        def `test_sparse_get_distributions`:
+            d%i: null
+            abc: null
+            c%i: null
+            ignore: null
+            .*: null
+        def `test_compute_distributions_metas`:
+            datasets/test9.tab: null
+            O: null
+    __main__: null
+tests/test_doctest.py:
+    Orange/widgets: null
+    Orange/canvas: null
+    Orange/datasets/: null
+    win32: null
+    def `find_modules`:
+        __file__: null
+        .py: null
+        .: null
+    def `suite`:
+        1.14: null
+        def `setUp`:
+            Skip doctest on numpy >= 1.14.0: null
+        'Unimportable module: {}': null
+tests/test_domain.py:
+    def `create_domain`:
+        AGE: null
+        Gender: null
+        M: null
+        F: null
+        incomeA: null
+        income: null
+        education: null
+        GS: null
+        HS: null
+        C: null
+        SSN: null
+        race: null
+        White: null
+        Hypsanic: null
+        African: null
+        Other: null
+        arrival: null
+    PickleDomain: null
+    empty_domain: null
+    with_continuous_variable: null
+    age: null
+    with_discrete_variable: null
+    gender: null
+    with_mixed_variables: null
+    with_continuous_class: null
+    incomeA: null
+    with_discrete_class: null
+    education: null
+    with_multiple_classes: null
+    with_metas: null
+    ssn: null
+    with_class_and_metas: null
+    income: null
+    race: null
+    arrival: null
+    class `TestDomainInit`:
+        def `test_init_source`:
+            Gender: null
+        def `test_init_source_class`:
+            Gender: null
+            income: null
+        def `test_from_numpy_names`:
+            Feature {}: null
+            Feature {:02}: null
+            Feature {:03}: null
+            Feature: null
+            Target: null
+            Meta {:03}: null
+        def `test_nonunique_domain_error`:
+            a: null
+        def `test_from_numpy_values`:
+            v{}: null
+        def `test_wrong_types`:
+            income: null
+        def `test_get_item`:
+            AGE: null
+            income: null
+            SSN: null
+        def `test_index`:
+            AGE: null
+            income: null
+            SSN: null
+        def `test_get_item_error`:
+            no_such_thing: null
+        def `test_index_error`:
+            no_such_thing: null
+        def `test_contains`:
+            AGE: null
+            income: null
+            SSN: null
+            no_such_thing: null
+        def `test_str`:
+            []: null
+            [AGE]: null
+            [ | AGE]: null
+            [Gender | AGE]: null
+            [Gender, income]: null
+            [Gender, income | AGE]: null
+            [Gender | AGE, income]: null
+            [Gender | AGE, income] {SSN}: null
+            [Gender | AGE, income] {SSN, race}: null
+            [] {SSN, race}: null
+        def `test_get_conversion`:
+            new_income: null
+        def `test_conversion`:
+            White: null
+            M: null
+            HS: null
+            1234567: null
+        def `test_preprocessor_chaining`:
+            a: null
+            01: null
+            b: null
+            y: null
+        def `test_different_domains_with_same_attributes_are_equal`:
+            var1: null
+        def `test_domain_conversion_is_fast_enough`:
+            f%i: null
+            c%i: null
+            m%i: null
+        def `test_domain_conversion_sparsity`:
+            a: null
+            b: null
+            c: null
+            d: null
+            e: null
+            f: null
+        def `test_get_item_similar_vars`:
+            Cluster: null
+            c: null
+            Cluster x: null
+            a: null
+            b: null
+    class `TestDomainFilter`:
+        def `setUp`:
+            iris: null
+        def `test_filter_visible`:
+            hidden: null
+    __main__: null
+tests/test_evaluation_clustering.py:
+    class `TestClusteringEvaluation`:
+        def `test_kmeans`:
+            iris: null
+tests/test_evaluation_scoring.py:
+    class `TestScoreMetaType`:
+        class `Score3`:
+            foo: null
+        def `test_registry`:
+            Score2: null
+            Score3: null
+            Score4: null
+            Score5: null
+        def `test_names`:
+            Score2: null
+            foo: null
+            Score4: null
+            Score5: null
+    class `TestPrecision`:
+        def `setUpClass`:
+            iris: null
+        def `test_precision_iris`:
+            weighted: null
+        def `test_precision_multiclass`:
+            y: null
+            01234: null
+            weighted: null
+        def `test_precision_binary`:
+            y: null
+            01: null
+            macro: null
+    class `TestRecall`:
+        def `setUpClass`:
+            iris: null
+        def `test_recall_iris`:
+            weighted: null
+        def `test_recall_multiclass`:
+            y: null
+            01234: null
+            weighted: null
+        def `test_recall_binary`:
+            y: null
+            01: null
+            macro: null
+    class `TestF1`:
+        def `setUpClass`:
+            iris: null
+        def `test_recall_iris`:
+            weighted: null
+        def `test_F1_multiclass`:
+            y: null
+            01234: null
+            weighted: null
+        def `test_F1_binary`:
+            y: null
+            01: null
+    class `TestAUC`:
+        def `setUpClass`:
+            iris: null
+        def `test_auc_on_multiclass_data_returns_1d_array`:
+            titanic: null
+            datasets/lenses.tab: null
+        def `compute_auc`:
+            x: null
+            01: null
+    class `TestLogLoss`:
+        def `test_log_loss`:
+            iris: null
+        def `test_log_loss_calc`:
+            titanic: null
+    class `TestMatthewsCorrCoefficient`:
+        def `setUpClass`:
+            heart_disease: null
+            iris: null
+            housing: null
+    class `TestSpecificity`:
+        def `setUpClass`:
+            iris: null
+        def `test_specificity_iris`:
+            weighted: null
+        def `test_precision_multiclass`:
+            y: null
+            01234: null
+            weighted: null
+        def `test_precision_binary`:
+            y: null
+            01: null
+        def `test_errors`:
+            binary: null
+            abc: null
+    __main__: null
+tests/test_evaluation_testing.py:
+    class `TestSampling`:
+        def `setUpClass`:
+            iris: null
+        def `run_test_failed`:
+            def `fails`:
+                failing learner: null
+        def `run_test_preprocessor`:
+            iris: null
+    class `TestValidation`:
+        def `setUp`:
+            iris: null
+        def `test_warn_deprecations`:
+            Orange.evaluation.testing.Validation.__call__: null
+        def `test_obsolete_call_constructor`:
+            Orange.evaluation.testing.Validation.__call__: null
+            n_jobs: null
+            callback: null
+            learners: null
+    class `TestCrossValidation`:
+        def `setUpClass`:
+            iris: null
+            housing: null
+        def `test_augmented_data_classification`:
+            iris: null
+            Naive Bayes: null
+            Majority: null
+        def `test_augmented_data_regression`:
+            housing: null
+            Linear Regression: null
+            Mean Learner: null
+    class `TestCrossValidationFeature`:
+        def `add_meta_fold`:
+            fold: null
+        def `test_init`:
+            fold: null
+            abc: null
+        def `test_unknown`:
+            nan: null
+        def `test_bad_feature`:
+            fold: null
+            abc: null
+            x: null
+            ab: null
+            y: null
+            cd: null
+    class `TestLeaveOneOut`:
+        def `test_probs`:
+            iris: null
+    class `TestTestOnTestData`:
+        def `run_test_failed`:
+            def `fails`:
+                failing learner: null
+        def `test_train_data_argument`:
+            Orange.evaluation.testing.Validation.__new__: null
+            data: null
+            test_data: null
+    class `TestTrainTestSplit`:
+        def `test_fixed_training_size`:
+            iris: null
+    class `TestResults`:
+        def `setUp`:
+            iris: null
+tests/test_filter.py:
+    class `TestFilterValues`:
+        def `setUp`:
+            iris: null
+        def `test_values`:
+            Orange.data.Table._filter_values: null
+    class `TestIsDefinedFilter`:
+        def `setUp`:
+            datasets/imports-85.tab: null
+        def `test_eq_hash`:
+            a: null
+            b: null
+        def `test_is_defined_filter_not_implemented`:
+            Orange.data.Table._filter_is_defined: null
+    class `TestHasClassFilter`:
+        def `setUp`:
+            datasets/imports-85.tab: null
+        def `test_has_class_multiclass`:
+            x: null
+            01: null
+            y1: null
+            y2: null
+        def `test_has_class_filter_not_implemented`:
+            Orange.data.Table._filter_has_class: null
+    class `TestFilterContinuous`:
+        def `setUp`:
+            abcd: null
+        def `test_position`:
+            a: null
+            b: null
+            c: null
+            d: null
+        def `test_str`:
+            feature(1) = 1: null
+            foo: null
+            foo = 1: null
+            a = 1: null
+            a ≠ 1: null
+            a < 1: null
+            a ≤ 1: null
+            a > 1: null
+            a ≥ 1: null
+            1 ≤ a ≤ 2: null
+            not 1 ≤ a ≤ 2: null
+            a is defined: null
+            invalid operator: null
+    class `TestFilterString`:
+        def `setUp`:
+            zoo: null
+        def `test_case_sensitive`:
+            name: null
+            Aardvark: null
+        def `test_operators`:
+            name: null
+            aardvark: null
+            bass: null
+            aa: null
+            a: null
+            aaz: null
+            ard: null
+            ra: null
+            aar: null
+            aard: null
+            ?: null
+            nan: null
+    class `TestSameValueFilter`:
+        def `setUp`:
+            zoo: null
+            type: null
+            legs: null
+            name: null
+            mammal: null
+            girl: null
+        def `test_same_value_filter_table`:
+            mammal: null
+            girl: null
+        def `test_has_class_filter_not_implemented`:
+            Orange.data.Table._filter_same_value: null
+    class `TestFilterReprs`:
+        def `setUp`:
+            zoo: null
+            type: null
+            mammal: null
+        def `test_reprs`:
+            name: null
+            Aardvark: null
+            ^c...$: null
+tests/test_fitter.py:
+    class `DummyFitter`:
+        dummy: null
+        classification: null
+        regression: null
+    class `FitterTest`:
+        def `setUpClass`:
+            heart_disease: null
+            housing: null
+        def `test_dispatches_to_correct_learner`:
+            Classification learner was never called for classification: null
+            problem: null
+            Regression learner was called for classification problem: null
+            Regression learner was never called for regression problem: null
+            Classification learner was called for regression problem: null
+        def `test_constructs_learners_with_appropriate_parameters`:
+            class `DummyFitter`:
+                classification: null
+                regression: null
+            Fitter did not properly distribute params to learners: null
+        def `test_correctly_sets_preprocessors_on_learner`:
+            Fitter did not properly pass the `use_default_preprocessors`: null
+            attribute to its learners: null
+            Fitter did not properly pass its preprocessors to its learners: null
+        def `test_properly_delegates_preprocessing`:
+            class `DummyFitter`:
+                classification: null
+                regression: null
+        def `test_default_kwargs_with_change_kwargs`:
+            class `DummyClassificationLearner`:
+                def `__init__`:
+                    classification_default: null
+            class `DummyRegressionLearner`:
+                def `__init__`:
+                    regression_default: null
+            class `DummyFitter`:
+                classification: null
+                regression: null
+                def `_change_kwargs`:
+                    param: null
+                    classification_param: null
+                    regression_param: null
+            iris: null
+            housing: null
+            classification_default: null
+            regression_default: null
+tests/test_freeviz.py:
+    class `TestFreeviz`:
+        def `setUpClass`:
+            iris: null
+            housing: null
+            zoo: null
+        def `test_regression`:
+            housing: null
+        def `test_weights`:
+            Test weights is too slow.: null
+            iris: null
+        def `test_raising_errors`:
+            iris: null
+            titanic: null
+        def `test_transform_changed_domain`:
+            titanic: null
+tests/test_fss.py:
+    class `TestFSS`:
+        def `setUpClass`:
+            titanic: null
+            heart_disease: null
+            iris: null
+            datasets/imports-85.tab: null
+    class `TestSelectRandomFeatures`:
+        def `test_select_random_features`:
+            heart_disease: null
+tests/test_impute.py:
+    class `TestDoNotImpute`:
+        def `test_str`:
+            iris: null
+        def `test_support`:
+            iris: null
+    class `TestAverage`:
+        def `test_replacement`:
+            a: null
+            b: null
+            ABC: null
+            c: null
+    class `TestDefault`:
+        def `test_default`:
+            B: null
+            a: null
+            b: null
+            c: null
+            C: null
+        def `test_str`:
+            1: null
+            y: null
+    class `TestAsValue`:
+        def `_create_table`:
+            A: null
+            0: null
+            1: null
+            2: null
+            B: null
+            C: null
+        def `test_replacement`:
+            1: null
+            2: null
+            N/A: NN
+            undef: ne
+            def: da
+        def `test_sparse`:
+            undef: ne
+            def: da
+    class `TestModel`:
+        def `test_replacement`:
+            A: null
+            0: null
+            1: null
+            2: null
+            B: null
+            C: null
+            Z: null
+            P: null
+            M: null
+        def `test_support`:
+            iris: null
+        def `test_str`:
+            y: null
+        def `test_bad_domain`:
+            iris: null
+    class `TestRandom`:
+        def `test_replacement`:
+            A: null
+            0: null
+            1: null
+            2: null
+            B: null
+            C: null
+    class `TestImputer`:
+        def `test_imputer`:
+            datasets/imports-85.tab: null
+tests/test_instance.py:
+    class `TestInstance`:
+        def `setUpClass`:
+            Feature %i: null
+            Class %i: null
+            Meta 1: null
+            XYZ: null
+            Meta 2: null
+            Meta 3: null
+        def `test_init_x_arr`:
+            x: null
+            g: null
+            MF: null
+        def `test_init_x_list`:
+            x: null
+            g: null
+            MF: null
+        def `test_init_xy_arr`:
+            x: null
+            g: null
+            MF: null
+            y: null
+            ABC: null
+        def `test_init_xy_list`:
+            x: null
+            g: null
+            MF: null
+            y: null
+            ABC: null
+        def `test_init_xym`:
+            x: null
+            g: null
+            MF: null
+            y: null
+            ABC: null
+            M: null
+            B: null
+            X: null
+            Foo: null
+        def `test_init_inst`:
+            x: null
+            g: null
+            MF: null
+            y: null
+            ABC: null
+            M: null
+            B: null
+            X: null
+            Foo: null
+            z: null
+            w: null
+        def `test_get_item`:
+            x: null
+            g: null
+            MF: null
+            y: null
+            ABC: null
+            M: null
+            B: null
+            X: null
+            Foo: null
+            Meta 2: null
+            asdf: null
+        def `test_list`:
+            x: null
+            g: null
+            MF: null
+            y: null
+            ABC: null
+            M: null
+            B: null
+            X: null
+            Foo: null
+        def `test_set_item`:
+            x: null
+            g: null
+            MF: null
+            y: null
+            ABC: null
+            M: null
+            B: null
+            X: null
+            Foo: null
+            F: null
+            C: null
+            A: null
+            Y: null
+            Meta 1: null
+            Z: null
+            N: null
+            asdf: null
+        def `test_str`:
+            x: null
+            g: null
+            MF: null
+            [42, M]: null
+            y: null
+            ABC: null
+            M: null
+            B: null
+            [42, M | B]: null
+            X: null
+            Foo: null
+            [42, M | B] {X, 43, Foo}: null
+            [ | B] {X, 43, Foo}: null
+            [] {X, 43, Foo}: null
+            [{}]: null
+            ', ': null
+            {x:g}: null
+            {}: null
+        def `test_repr`:
+            [0, 1, 2, 3, 4, ...]: null
+            [0.000, 1.000, 2.000, 3.000, 4.000, ...]: null
+        def `test_eq`:
+            x: null
+            g: null
+            MF: null
+            y: null
+            ABC: null
+            M: null
+            B: null
+            X: null
+            Foo: null
+            C: null
+            Y: null
+            33: null
+            Bar: null
+        def `test_instance_id`:
+            x: null
+    __main__: null
+tests/test_io.py:
+    class `WildcardReader`:
+        .wild: null
+        .wild[0-9]: null
+        Dummy reader for testing extensions: null
+    class `TestChooseReader`:
+        def `test_usual_extensions`:
+            t.tab: null
+            t.csv: null
+            t.pkl: null
+            test.undefined_extension: null
+        def `test_wildcard_extension`:
+            t.wild: null
+            t.wild2: null
+            t.wild2a: null
+    class `SameExtension`:
+        .same_extension: null
+        Same extension, different priority: null
+    class `TestMultipleSameExtension`:
+        def `test_find_reader`:
+            some.same_extension: null
+    class `TestLocate`:
+        def `test_locate_sample_datasets`:
+            iris.tab: null
+            iris: null
+        def `test_locate_wildcard_extension`:
+            t.wild9: null
+            t.wild8: null
+            wt: null
+            \n: null
+            t: null
+    class `TestReader`:
+        def `test_open_bad_pickle`:
+            pickle.load: null
+            foo: null
+        def `test_empty_columns`:
+            '\
+        a, b
+        1, 0,
+        1, 2,
+        ': null
+            Columns with no headers were removed.: null
+        def `test_type_annotations`:
+            test_file: null
+        def `test_header_call`:
+            csv.DictWriter.writerow: null
+            iris: null
+        def `test_load_pickle`:
+            default: null
+            datasets/sailing-orange-3-20.pkl: null
+            datasets/sailing-orange-3-20.pkl.gz: null
+            datasets/sailing-orange-3-21.pkl: null
+            datasets/sailing-orange-3-21.pkl.gz: null
+    __main__: null
+tests/test_knn.py:
+    class `TestKNNLearner`:
+        def `setUpClass`:
+            iris: null
+            housing: null
+        def `test_nan`:
+            Feat 1: null
+            Class: null
+        def `test_random`:
+            Feature 1: null
+            Feature 2: null
+            Feature 3: null
+            Feature 4: null
+            Feature 5: null
+            Target 1: null
+            abcdefghij: null
+        def `test_KNN_mahalanobis`:
+            mahalanobis: null
+        def `test_KNN_regression`:
+            mahalanobis: null
+tests/test_lda.py:
+    class `TestLDA`:
+        def `test_lda`:
+            iris: null
+            eigen: null
+        def `test_transform_changed_domain`:
+            iris: null
+tests/test_linear_bfgs_regression.py:
+    class `TestLinearRegressionLearner`:
+        def `test_preprocessors`:
+            housing: null
+tests/test_linear_regression.py:
+    class `TestLinearRegressionLearner`:
+        def `setUpClass`:
+            housing: null
+        def `test_linear_scorer`:
+            LSTAT: null
+        def `test_scorer`:
+            LSTAT: null
+tests/test_logistic_regression.py:
+    class `TestLogisticRegressionLearner`:
+        def `setUpClass`:
+            iris: null
+            heart_disease.tab: null
+            zoo: null
+        def `test_LogisticRegressionNormalization`:
+            Re-enable when Logistic regression supports normalization.: null
+            c0: null
+        def `test_probability`:
+            l1: null
+        def `test_learner_scorer`:
+            chest pain: null
+        def `test_learner_scorer_multiclass`:
+            legs: null
+            feathers: null
+            fins: null
+            backbone: null
+            milk: null
+            aquatic: null
+        def `test_auto_solver`:
+            l2: null
+            auto: null
+            lbfgs: null
+            l1: null
+            liblinear: null
+tests/test_majority.py:
+    class `TestMajorityLearner`:
+        def `setUpClass`:
+            iris: null
+        def `test_missing`:
+            iris: null
+            ?: null
+        def `test_continuous`:
+            datasets/imports-85.tab: null
+        def `test_returns_random_class`:
+            bool: null
+            Majority always returns the same value.: null
+tests/test_manifold.py:
+    class `TestManifold`:
+        def `setUpClass`:
+            datasets/ionosphere.tab: null
+            iris: null
+        def `__mds_test_helper`:
+            precomputed: null
+            euclidean: null
+        def `test_mds_pca_init`:
+            PCA: null
+            precomputed: null
+            euclidean: null
+        def `__lle_test_helper`:
+            ltsa: null
+            dense: null
+            hessian: null
+            modified: null
+        def `test_torgerson`:
+            auto: null
+            lapack: null
+            arpack: null
+            madness: null
+    class `TestTSNE`:
+        def `setUpClass`:
+            iris: null
+        def `test_continue_optimization`:
+            Embedding should change after further optimization.: null
+        def `test_bh_correctness`:
+            bh: null
+            random: null
+        def `test_fft_correctness`:
+            fft: null
+            random: null
+        def `test_pickle`:
+            Windows: null
+            Files locked on Windows: null
+            exact: null
+            approx: null
+            Pickling failed with `neighbors={neighbors}`: null
+tests/test_mean.py:
+    class `TestMeanLearner`:
+        def `test_empty`:
+            datasets/imports-85.tab: null
+        def `test_discrete`:
+            iris: null
+tests/test_naive_bayes.py:
+    class `TestNaiveBayesLearner`:
+        def `setUpClass`:
+            titanic: null
+        def `test_NaiveBayes`:
+            iris: null
+        def `test_degenerate`:
+            A: null
+            B: null
+            C: null
+            CLASS: null
+            M: null
+            F: null
+        def `test_allnan_cv`:
+            datasets/lenses.tab: null
+        def `test_compare_results_of_predict_and_predict_storage`:
+            titanic: null
+        def `_test_predictions`:
+            a: null
+            ab: null
+            b: null
+            abc: null
+            c: null
+            y: null
+        def `_test_predictions_with_absent_class`:
+            a: null
+            ab: null
+            b: null
+            abc: null
+            c: null
+            y: null
+            abcd: null
+        def `test_no_attributes`:
+            y: null
+            abc: null
+        def `test_no_targets`:
+            x: null
+            abc: null
+            y: null
+    __main__: null
+tests/test_neural_network.py:
+    class `TestNNLearner`:
+        def `setUpClass`:
+            iris: null
+            housing: null
+        def `setUp`:
+            ignore: null
+            .*: null
+tests/test_normalize.py:
+    class `TestNormalizer`:
+        def `compare_tables`:
+            c1: null
+            c2: null
+            d1: null
+            d2: null
+            n1: null
+            n2: null
+            c3: null
+            d3: null
+            c4: null
+            cl1: null
+            cl2: null
+        def `setUpClass`:
+            datasets/test5.tab: null
+        def `test_normalize_default`:
+            a: null
+            ?: null
+            b: null
+            c: null
+        def `test_normalize_transform_by_sd`:
+            a: null
+            ?: null
+            b: null
+            c: null
+        def `test_normalize_transform_class`:
+            a: null
+            ?: null
+            b: null
+            c: null
+        def `test_normalize_transform_by_span`:
+            a: null
+            ?: null
+            b: null
+            c: null
+        def `test_normalize_transform_by_span_zero`:
+            a: null
+            ?: null
+            b: null
+            c: null
+        def `test_normalize_transform_by_span_class`:
+            a: null
+            ?: null
+            b: null
+            c: null
+        def `test_normalize_transform_by_span_zero_class`:
+            a: null
+            ?: null
+            b: null
+            c: null
+        def `test_skip_normalization`:
+            skip-normalization: null
+        def `test_datetime_normalization`:
+            datasets/test10.tab: null
+            1995-01-21: null
+            a: null
+            ?: null
+            2003-07-23: null
+            b: null
+            1967-03-12: null
+            c: null
+        def `test_retain_vars_attributes`:
+            iris: null
+            foo: null
+            baz: null
+        def `test_number_of_decimals`:
+            Foo: null
+            -1.225: null
+            0.0: null
+            1.225: null
+    __main__: null
+tests/test_orange.py:
+    class `TestOrange`:
+        def `test_orange_has_modules`:
+            canvas: null
+            datasets: null
+            testing: null
+            tests: null
+            setup: null
+            util: null
+            widgets: null
+tests/test_orangetree.py:
+    class `TestTree`:
+        def `test_refuse_binarize_too_many_values`:
+            x: null
+            v{}: null
+        def `test_find_mapping`:
+            x: null
+            abcdefgh: null
+            r1: null
+            r2: null
+            abcd: null
+        def `test_find_threshold`:
+            x: null
+            r1: null
+            abcd: null
+            r2: null
+        def `test_no_data`:
+            r1: null
+            ab: null
+            r2: null
+            abcd: null
+            r3: null
+        def `test_all_values_missing`:
+            r1: null
+            ab: null
+            r2: null
+            abcd: null
+            r3: null
+        def `test_single_valued_attr`:
+            r1: null
+            a: null
+        def `test_allow_null_nodes`:
+            x: null
+            abc: null
+            r1: null
+            r2: null
+            ab: null
+    class `TestClassifier`:
+        def `setUpClass`:
+            sufficient_majority: null
+            iris: null
+            heart_disease: null
+            y: null
+            nyx: null
+    class `TestRegressor`:
+        def `setUpClass`:
+            housing: null
+            datasets/imports-85.tab: null
+            y: null
+    class `TestNodes`:
+        def `test_node`:
+            y: null
+            foo: null
+        def `test_discrete_node`:
+            y: null
+            abc: null
+            foo: null
+            nan: null
+        def `test_mapped_node`:
+            y: null
+            abc: null
+            foo: null
+            nan: null
+            1001: null
+        def `test_numeric_node`:
+            y: null
+            foo: null
+            nan: null
+    class `TestTreeModel`:
+        def `setUp`:
+            v1: null
+            v2: null
+            abc: null
+            v3: null
+            def: null
+            y: null
+        def `test_compile_and_run_cont`:
+            nan: null
+            d1: null
+            d2: null
+            abc: null
+            d3: null
+            def: null
+            dy: null
+        def `test_null_nodes`:
+            d4: null
+            ab: null
+            ey: null
+        def `test_print`:
+            '             [ 1 42] v1 ≤ 13
+             [ 2 42]     v2 a
+             [ 3 42]     v2 b
+             [ 4 42]     v2 c
+             [ 5 42] v1 > 13
+             [ 6 42]     v3 f
+             [ 7 42]     v3 d or e
+': '             [ 1 42] v1 ≤ 13
+             [ 2 42]     v2 a
+             [ 3 42]     v2 b
+             [ 4 42]     v2 c
+             [ 5 42] v1 > 13
+             [ 6 42]     v3 f
+             [ 7 42]     v3 d ali e
+'
+        def `test_compile_and_run_cont_sparse`:
+            nan: null
+tests/test_pca.py:
+    class `TestPCA`:
+        def `setUpClass`:
+            datasets/ionosphere.tab: null
+            iris: null
+            zoo: null
+        def `__rnd_pca_test_helper`:
+            randomized: null
+        def `test_improved_randomized_pca_properly_called`:
+            randomized: null
+            arpack: null
+        def `test_improved_randomized_pca_dense_data`:
+            full: null
+            randomized: null
+        def `test_improved_randomized_pca_sparse_data`:
+            full: null
+            randomized: null
+        def `test_incremental_pca`:
+            0.20: null
+            https://github.com/scikit-learn/scikit-learn/issues/12234: null
+        def `test_PCA_scorer`:
+            petal length: null
+            petal width: null
+tests/test_polynomial_learner.py:
+    class `TestPolynomialLearner`:
+        def `test_PolynomialLearner`:
+            x: null
+            y: null
+tests/test_preprocess.py:
+    class `TestRemoveConstant`:
+        def `test_nothing_to_remove`:
+            iris: null
+    class `TestRemoveNaNRows`:
+        def `test_remove_row`:
+            iris: null
+    class `TestRemoveNaNColumns`:
+        def `test_column_filtering`:
+            iris: null
+        def `test_column_filtering_sparse`:
+            iris: null
+    class `TestAdaptiveNormalize`:
+        def `setUp`:
+            iris: null
+    class `TestRemoveSparse`:
+        def `setUp`:
+            a: null
+            b: null
+    __main__: null
+tests/test_preprocess_cur.py:
+    class `TestCURProjector`:
+        def `setUpClass`:
+            datasets/ionosphere.tab: null
+tests/test_preprocess_pca.py:
+    class `TestPCAProjector`:
+        def `setUpClass`:
+            datasets/ionosphere.tab: null
+tests/test_radviz.py:
+    class `TestRadViz`:
+        def `setUpClass`:
+            iris: null
+            titanic: null
+tests/test_random_forest.py:
+    class `RandomForestTest`:
+        def `setUpClass`:
+            iris: null
+            housing: null
+        def `test_classification_scorer`:
+            petal length: null
+            petal width: null
+        def `test_regression_scorer`:
+            LSTAT: null
+            RM: null
+        def `test_scorer_feature`:
+            datasets/test4.tab: null
+        def `test_max_features_cls`:
+            heart_disease: null
+    __main__: null
+tests/test_randomize.py:
+    class `TestRandomizer`:
+        def `setUpClass`:
+            zoo: null
+        def `test_randomize_keep_original_data`:
+            zoo: null
+tests/test_regression.py:
+    def `all_learners`:
+        Orange.regression.: null
+        base: null
+    class `TestRegression`:
+        def `test_adequacy_all_learners`:
+            iris: null
+        def `test_adequacy_all_learners_multiclass`:
+            datasets/test8.tab: null
+        def `test_missing_class`:
+            datasets/imports-85.tab: null
+    __main__: null
+tests/test_remove.py:
+    class `TestRemover`:
+        def `setUpClass`:
+            datasets/test8.tab: null
+        def `test_remove`:
+            iris: null
+            sepal length: null
+            sepal width: null
+            petal length: null
+            removed: null
+            reduced: null
+            sorted: null
+        def `test_remove_constant_attr`:
+            c0: null
+            d0: null
+            cl1: null
+            cl0: null
+            cl3: null
+            cl4: null
+            4: null
+            6: null
+            1: null
+            2: null
+            3: null
+            removed: null
+            reduced: null
+            sorted: null
+        def `test_remove_constant_class`:
+            c1: null
+            c0: null
+            d1: null
+            d0: null
+            cl1: null
+            cl0: null
+            1: null
+            4: null
+            6: null
+            2: null
+            3: null
+            removed: null
+            reduced: null
+            sorted: null
+        def `test_remove_unused_values_attr`:
+            c1: null
+            c0: null
+            d1: null
+            d0: null
+            cl1: null
+            cl0: null
+            cl3: null
+            cl4: null
+            1: null
+            4: null
+            2: null
+            3: null
+            removed: null
+            reduced: null
+            sorted: null
+        def `test_remove_unused_values_class`:
+            c1: null
+            c0: null
+            d1: null
+            d0: null
+            cl1: null
+            cl0: null
+            cl3: null
+            cl4: null
+            1: null
+            4: null
+            6: null
+            2: null
+            3: null
+            removed: null
+            reduced: null
+            sorted: null
+        def `test_remove_unused_values_metas`:
+            datasets/test9.tab: null
+            b: null
+            c: null
+            d: null
+            1: null
+            2: null
+            f: null
+            hey: null
+        def `test_remove_unused_values_attr_sparse`:
+            1: null
+            4: null
+            2: null
+            3: null
+            removed: null
+            reduced: null
+            sorted: null
+        def `test_remove_mapping`:
+            iris: null
+        def `test_remove_mapping_after_compute_value`:
+            housing: null
+tests/test_rules.py:
+    class `TestRuleInduction`:
+        def `setUp`:
+            titanic: null
+            iris: null
+        def `test_base_RuleLearner`:
+            data_stopping: null
+            cover_and_remove: null
+            rule_stopping: null
+            rule_finder: null
+            search_algorithm: null
+            search_strategy: null
+            quality_evaluator: null
+            complexity_evaluator: null
+            general_validator: null
+            significance_validator: null
+        def `testOrderedCN2SDLearner`:
+            gamma: null
+        def `testUnorderedCN2SDLearner`:
+            gamma: null
+    __main__: null
+tests/test_score_feature.py:
+    class `FeatureScoringTest`:
+        def `setUpClass`:
+            zoo: null
+            housing: null
+            datasets/breast-cancer-wisconsin.tab: null
+            datasets/lenses.tab: null
+        def `test_chi2`:
+            c: null
+        def `test_anova`:
+            c: null
+        def `test_relieff`:
+            Bare_Nuclei: null
+            Clump thickness: null
+            Marginal_Adhesion: null
+            tear_rate: null
+        def `test_rrelieff`:
+            LSTAT: null
+            RM: null
+        def `test_fcbf`:
+            legs: null
+            milk: null
+            toothed: null
+            feathers: null
+            backbone: null
+            1: null
+            2: null
+            target: null
+            ignore: null
+            invalid value.*double_scalars: null
+            invalid value.*true_divide: null
+        def `test_learner_with_transformation`:
+            iris: null
+        def `test_learner_transform_without_variable`:
+            def `preprocessor_random_column`:
+                nat: null
+    __main__: null
+tests/test_sgd.py:
+    class `TestSGDRegressionLearner`:
+        def `setUp`:
+            ignore: null
+            .*: null
+        def `test_coefficients`:
+            housing: null
+    class `TestSGDClassificationLearner`:
+        def `setUpClass`:
+            iris: null
+        def `setUp`:
+            ignore: null
+            .*: null
+        def `test_predictions_shapes`:
+            modified_huber: null
+tests/test_simple_random_forest.py:
+    class `TestSimpleRandomForestLearner`:
+        def `test_SimpleRandomForest_classification`:
+            iris: null
+        def `test_SimpleRandomForest_regression`:
+            housing: null
+    __main__: null
+tests/test_simple_tree.py:
+    class `TestSimpleTreeLearner`:
+        def `setUp`:
+            d{}: null
+            0: null
+            1: null
+            c{}: null
+            yc: null
+            2: null
+            yr: null
+        def `test_SimpleTree_classification_tree`:
+            '{ 1 4 -1.17364 { 1 5 0.37564 { 2 0.00 0.00 0.56 } ': null
+            '{ 2 0.00 3.00 1.14 } } { 1 4 -0.41863 { 1 5 0.14592 ': null
+            '{ 2 3.54 0.54 0.70 } { 2 2.46 0.46 2.47 } } { 1 4 0.24404 ': null
+            '{ 1 4 0.00654 { 1 3 -0.15750 { 2 1.00 0.00 0.45 } ': null
+            '{ 2 1.00 3.00 0.48 } } { 2 1.00 5.00 0.70 } } { 1 5 0.32635 ': null
+            { 2 0.52 2.52 4.21 } { 2 2.48 3.48 1.30 } } } } }: null
+        def `test_SimpleTree_regression_tree`:
+            '{ 0 2 { 1 4 0.13895 { 1 4 -0.32607 { 2 4.60993 1.71141 } ': null
+            '{ 2 4.96454 3.56122 } } { 2 7.09220 -4.32343 } } { 1 4 -0.35941 ': null
+            '{ 0 0 { 1 5 -0.20027 { 2 3.54255 0.95095 } { 2 5.50000 -5.56049 } ': null
+            '} { 2 7.62411 2.03615 } } { 1 5 0.40797 { 1 3 0.83459 ': null
+            '{ 2 3.71094 0.27028 } { 2 5.18490 3.70920 } } { 2 5.77083 5.93398 ': null
+            } } } }: null
+        def `test_SimpleTree_single_instance`:
+            iris: null
+        def `test_SimpleTree_to_string_classification`:
+            d1: null
+            ef: null
+            c1: null
+            cls: null
+            abc: null
+            e: null
+            a: null
+            b: null
+            f: null
+            c: null
+            \n: null
+            d1 ([2.0, 2.0, 2.0])\n: null
+            ': e\n': null
+            '   c1 ([2.0, 2.0, 0.0])\n': null
+            '   : <=2.5\n': null
+            '      c1 ([1.0, 2.0, 0.0])\n': null
+            '      : <=1.5 --> a ([1.0, 1.0, 0.0])\n': null
+            '      : >1.5 --> b ([0.0, 1.0, 0.0])\n': null
+            '   : >2.5 --> a ([1.0, 0.0, 0.0])\n': null
+            ': f --> c ([0.0, 0.0, 2.0])': null
+        def `test_SimpleTree_to_string_regression`:
+            d1: null
+            ef: null
+            c1: null
+            cls: null
+            e: null
+            f: null
+            \n: null
+            'd1 (20: 6.0)\n': null
+            ': e\n': null
+            '   c1 (15: 4.0)\n': null
+            '   : <=2.5\n': null
+            '      c1 (16.6667: 3.0)\n': null
+            '      : <=1.5 --> (15: 2.0)\n': null
+            '      : >1.5 --> (20: 1.0)\n': null
+            '   : >2.5 --> (10: 1.0)\n': null
+            ': f --> (30: 2.0)': null
+        def `test_SimpleTree_to_string_cls_decimals`:
+            datasets/lenses.tab: null
+            '   astigmatic ([4.0, 3.0, 5.0])': null
+            \n: null
+        def `test_SimpleTree_to_string_reg_decimals`:
+            housing: null
+            '   LSTAT (19.9: 430.0)': null
+            \n: null
+    __main__: null
+tests/test_softmax_regression.py:
+    class `TestSoftmaxRegressionLearner`:
+        def `setUpClass`:
+            iris: null
+tests/test_sparse_reader.py:
+    '\
+abc, def, g=1, h ,  ij k  =5,   t # ignore this, foo=42
+
+def  , g   , h,ij,kl=4,m,,,
+# nothing here
+\t\t\tdef
+': null
+    '\
+abc, g=1, h ,  ij | k  =5,   t # ignore this, foo=42
+
+, g   , h,ij|,kl=4, k ;m,,,
+# nothing here
+\t\t\t;def
+': null
+    class `TestTabReader`:
+        def `test_read_simple`:
+            ascii: null
+            abc: null
+            def: null
+            g: null
+            h: null
+            ij k: null
+            t: null
+            ij: null
+            kl: null
+            m: null
+        def `test_read_complex`:
+            ascii: null
+            abc: null
+            g: null
+            h: null
+            ij: null
+            k: null
+            t: null
+            kl: null
+            m: null
+            def: null
+    __main__: null
+tests/test_sparse_table.py:
+    class `InterfaceTest`:
+        def `test_row_assignment`:
+            ignore: null
+            .*: null
+        def `test_value_assignment`:
+            ignore: null
+            .*: null
+        def `test_str`:
+            iris: null
+        def `test_Y_setter_1d`:
+            iris: null
+        def `test_Y_setter_2d`:
+            iris: null
+        def `test_Y_setter_2d_single_instance`:
+            iris: null
+tests/test_stack.py:
+    class `TestStackedFitter`:
+        def `setUpClass`:
+            iris: null
+            housing: null
+tests/test_statistics.py:
+    def `dense_sparse`:
+        def `_wrapper`:
+            def `sparse_with_explicit_zero`:
+                Can not inject explicit zero into non-sparse matrix: null
+                ignore: null
+                .*: null
+    class `TestUtil`:
+        def `setUp`:
+            nan: null
+        def `test_stats_non_numeric`:
+            a: null
+            b: null
+        def `test_stats_long_string_mem_use`:
+            a: null
+        def `test_nanmin_nanmax`:
+            ignore: null
+            .*All-NaN slice encountered.*: null
+        def `test_mean`:
+            ignore: null
+            .*mean\(\) resulted in nan.*: null
+tests/test_svm.py:
+    class `TestSVMLearner`:
+        def `setUpClass`:
+            datasets/ionosphere.tab: null
+        def `test_LinearSVM`:
+            ignore: null
+            .*: null
+        def `test_SVR`:
+            rbf: null
+        def `test_NuSVR`:
+            rbf: null
+    __main__: null
+tests/test_tab_reader.py:
+    class `TestTabReader`:
+        def `test_read_easy`:
+            '\
+        Feature 1\tFeature 2\tClass 1\tClass 42
+        d        \tM F      \td      \td
+                 \t         \tclass  \tclass
+        1.0      \tM        \t5      \trich
+                 \tF        \t7      \tpoor
+        2.0      \tM        \t4      \t
+        ': null
+            Feature 1: null
+            Feature 2: null
+            Class 1: null
+            Class 42: null
+        def `test_read_save_quoted`:
+            '\
+        S\tA
+        s\td
+        m\t
+        """a"""\ti
+        """b"""\tj
+        """c\td"""\tk
+        ': null
+            '"a"': null
+            '"b"': null
+            '"c\td"': null
+        def `test_read_and_save_attributes`:
+            '\
+        Feature 1\tFeature 2\tClass 1\tClass 42
+        d        \tM F      \td      \td
+                 \ta=1 b=2 \tclass x=a\\ longer\\ string \tclass
+        1.0      \tM        \t5      \trich
+        ': null
+            Feature 2: null
+            a: null
+            b: null
+            Class 1: null
+            x: null
+            a longer string: null
+            /path/to/somewhere: null
+            path: null
+        def `test_read_data_oneline_header`:
+            '\
+        data1\tdata2\tdata3
+        0.1\t0.2\t0.3
+        1.1\t1.2\t1.5
+        ': null
+            data1: null
+        def `test_read_data_no_header`:
+            '\
+        0.1\t0.2\t0.3
+        1.1\t1.2\t1.5
+        ': null
+            Feature 1: null
+        def `test_read_data_no_header_feature_reuse`:
+            '\
+        0.1\t0.2\t0.3
+        1.1\t1.2\t1.5
+        ': null
+        def `test_renaming`:
+            '\
+            a\t  b\t  a\t  a\t  b\t     a\t     c\t  a\t b
+            c\t  c\t  c\t  c\t  c\t     c\t     c\t  c\t c
+             \t   \t  \t   \t   class\t class\t  \t  \t  meta
+            0\t  0\t  0\t  0\t  0\t     0\t     0\t  0 ': null
+            wt: null
+            .tab: null
+            a (1): null
+            b (1): null
+            a (2): null
+            a (3): null
+            c: null
+            a (5): null
+            b (2): null
+            a (4): null
+            b (3): null
+        def `test_dataset_with_weird_names_and_column_attributes`:
+            datasets/weird.tab: null
+            5534fab7fad58d5df50061f1: null
+            5534fab8fad58d5de20061f8: null
+            Gene expressions (dd_AX4_on_Ka_20Hr_bio1_mapped.bam): null
+            Gene expressions (dd_AX4_on_Ka_20Hr_bio2_mapped.bam): null
+            1: null
+            2: null
+        def `test_sheets`:
+            \n: null
+            xd dbac: null
+        def `test_attributes_saving`:
+            test: null
+            out.tab: null
+        def `test_attributes_saving_as_txt`:
+            a: null
+            aa: null
+            b: null
+            bb: null
+            out.tab: null
+        def `test_data_name`:
+            iris: null
+        def `test_metadata`:
+            a: null
+            aa: null
+            b: null
+            bb: null
+            out.tab: null
+            .metadata: null
+        def `test_no_metadata`:
+            out.tab: null
+            .metadata: null
+        def `test_had_metadata_now_there_is_none`:
+            a: null
+            aa: null
+            out.tab: null
+            .metadata: null
+        def `test_number_of_decimals`:
+            heart_disease: null
+            age: null
+            ST by exercise: null
+            housing: null
+            CRIM: null
+            INDUS: null
+            AGE: null
+        def `test_many_discrete`:
+            Poser\nd\n\n: null
+            K: null
+            \n: null
+tests/test_table.py:
+    class `TableTestCase`:
+        def `test_indexing_class`:
+            datasets/test1: null
+            t: null
+            f: null
+            d: null
+        def `test_filename`:
+            iris: null
+            iris.tab: null
+            datasets/test2.tab: null
+            test2.tab: null
+        def `test_indexing`:
+            ignore: null
+            datasets/test2: null
+            c: null
+            0: null
+            b: null
+            a: null
+            A: null
+            e: null
+            i: null
+        def `test_indexing_example`:
+            ignore: null
+            datasets/test2: null
+            c: null
+            0: null
+            b: null
+            a: null
+            A: null
+            e: null
+            i: null
+        def `test_indexing_assign_value`:
+            ignore: null
+            datasets/test2: null
+            a: null
+            A: null
+            B: null
+            b: null
+        def `test_indexing_assign_example`:
+            ignore: null
+            datasets/test2: null
+            a: null
+            3.14: null
+            1: null
+            f: null
+            t: null
+            0: null
+            3.16: null
+            e: null
+            mmmapp: null
+        def `test_slice`:
+            ignore: null
+            datasets/test2: null
+        def `test_assign_slice_value`:
+            ignore: null
+            datasets/test2: null
+            b: null
+            a: null
+            A: null
+            ABAAACCDE: null
+        def `test_multiple_indices`:
+            ignore: null
+            datasets/test2: null
+        def `test_assign_multiple_indices_value`:
+            ignore: null
+            datasets/test2: null
+            b: null
+            ?: null
+        def `test_set_multiple_indices_example`:
+            ignore: null
+            datasets/test2: null
+        def `test_bool`:
+            iris: null
+            datasets/test3: null
+        def `test_checksum`:
+            zoo: null
+            name: null
+            non-animal: null
+        def `test_total_weight`:
+            zoo: null
+        def `test_has_missing`:
+            zoo: null
+            ?: null
+            datasets/test3: null
+        def `test_shuffle`:
+            zoo: null
+            name: null
+        def `test_copy_sparse`:
+            iris: null
+        def `test_concatenate`:
+            abc: null
+            y: null
+            ABC: null
+            m1: null
+            m2: null
+            foo: null
+            bar: null
+            baz: null
+            qux: null
+            a: null
+            c: null
+            b: null
+            d: null
+            e: null
+            f: null
+            t2: null
+            g: null
+            h: null
+            i: null
+            j: null
+            k: null
+            l: null
+            m: null
+            n: null
+            t3: null
+        def `test_concatenate_exceptions`:
+            zoo: null
+            iris: null
+        def `test_concatenate_sparse`:
+            iris: null
+            Concatenated X is not sparse.: null
+            Concatenated Y is not dense.: null
+            Concatenated metas is not dense.: null
+        def `test_pickle`:
+            zoo: null
+            iris: null
+        def `test_pickle_setstate`:
+            zoo: null
+            Orange.data.Table.__setstate__: null
+            X: null
+            _Y: null
+            metas: null
+            W: null
+            _X: null
+            Y: null
+            _metas: null
+            _W: null
+        def `test_translate_through_slice`:
+            iris: null
+            petal length: null
+            sepal length: null
+        def `test_saveTab`:
+            iris: null
+            test-save.tab: null
+            test-save.tab.metadata: null
+            a: null
+            zoo: null
+            test-zoo.tab: null
+            test-zoo: null
+            Meta attributes don't match.: null
+            Attributes don't match.: null
+            Weights don't match.: null
+            test-zoo.tab.metadata: null
+            test-zoo-weights.tab: null
+            test-zoo-weights: null
+            test-zoo-weights.tab.metadata: null
+        def `test_save_pickle`:
+            iris: null
+            iris.pickle: null
+        def `test_from_numpy`:
+            d: null
+            abcd: null
+            e: null
+            no: null
+            yes: null
+            f: null
+        def `test_filter_is_defined`:
+            iris: null
+        def `test_filter_has_class`:
+            iris: null
+        def `test_filter_random`:
+            iris: null
+            Filter returns too uneven distributions: null
+        def `test_filter_values_nested`:
+            iris: null
+        def `test_filter_string_works_for_numeric_columns`:
+            s: null
+            5: null
+            15: null
+            2: null
+            rows: null
+            {} returned wrong number of rows: null
+        def `test_filter_value_continuous`:
+            iris: null
+        def `test_filter_value_continuous_args`:
+            iris: null
+            petal length: null
+            sepal length: null
+        def `test_valueFilter_discrete`:
+            zoo: null
+            mammal: null
+            martian: null
+        def `test_valueFilter_string_is_defined`:
+            datasets/test9.tab: null
+        def `test_valueFilter_discrete_meta_is_defined`:
+            datasets/test9.tab: null
+        def `test_valueFilter_string_case_sens`:
+            zoo: null
+            name: null
+            girl: null
+            lion: null
+            ea: null
+            sea: null
+            ion: null
+        def `test_valueFilter_string_case_insens`:
+            zoo: null
+            name: null
+            girl: null
+            GIrl: null
+            giRL: null
+            CHiCKEN: null
+            chicken: null
+            liOn: null
+            lion: null
+            iR: null
+            ir: null
+            GI: null
+            gi: null
+            ion: null
+        def `test_valueFilter_regex`:
+            zoo: null
+            name: null
+            ^c...$: null
+        def `test_valueFilter_stringList`:
+            zoo: null
+            name: null
+            swan: null
+            tuna: null
+            wasp: null
+            WoRm: null
+            TOad: null
+            vOLe: null
+            rows: null
+            {} returned wrong number of rows: null
+        def `test_table_dtypes`:
+            iris: null
+        def `test_attributes`:
+            iris: null
+            test: null
+            modified: null
+        def `test_is_sparse`:
+            iris: null
+        def `test_repr_sparse_with_one_row`:
+            iris: null
+            \n: null
+            '[[sepal length=5.1, sepal width=3.5, ': null
+            petal length=1.4, petal width=0.2 | Iris-setosa]]: null
+        def `test_str`:
+            iris: null
+            [5.1, 3.5, 1.4, 0.2 | Iris-setosa]: null
+            \n: null
+            [[5.1, 3.5, 1.4, 0.2 | Iris-setosa],: null
+            ' [5.9, 3.0, 5.1, 1.8 | Iris-virginica]]': null
+        def `test_str_sparse`:
+            iris: null
+            '[sepal length=5.1, sepal width=3.5, ': null
+            petal length=1.4, petal width=0.2 | Iris-setosa]: null
+            \n: null
+            [: null
+            ,: null
+            '[sepal length=5.9, sepal width=3.0, ': null
+            petal length=5.1, petal width=1.8 | Iris-virginica]: null
+            ' ': null
+            ]: null
+    class `TableTests`:
+        Feature %i: null
+        Class %i: null
+        Meta %i: null
+    class `CreateTableWithFilename`:
+        data.tab: null
+        def `test_read_data_calls_reader`:
+            os.path.exists: null
+            .xlsx: null
+            test.xlsx: null
+        def `test_raises_error_if_file_does_not_exist`:
+            os.path.exists: null
+        def `test_raises_error_if_file_has_unknown_extension`:
+            os.path.exists: null
+            file.invalid_extension: null
+        def `test_calling_new_with_string_argument_calls_read_data`:
+            Orange.data.table.Table.from_file: null
+        def `test_calling_new_with_keyword_argument_filename_calls_read_data`:
+            Orange.data.table.Table.from_file: null
+    class `CreateTableWithUrl`:
+        def `test_url_no_scheme`:
+            www.foo.bar/xx.csv: null
+            Orange.data.io.UrlReader.urlopen: null
+            http://: null
+        class `_MockUrlOpen`:
+            content-disposition: null
+            'attachment; filename="Something-FormResponses.tsv"; ': null
+            filename*=UTF-8: null
+            Something%20%28Responses%29.tsv: null
+            def `read`:
+                '\
+a\tb\tc
+1\t2\t3
+2\t3\t4': null
+        def `test_trimmed_urls`:
+            Orange.data.io.urlopen: null
+            https://docs.google.com/spreadsheets/d/ABCD/edit: null
+            https://www.dropbox.com/s/ABCD/filename.csv: null
+            Mozilla/5.0: null
+            User-agent: null
+            Something-FormResponses: null
+    class `CreateTableWithDomain`:
+        def `test_calling_new_with_domain_calls_new_from_domain`:
+            Orange.data.table.Table.from_domain: null
+    class `CreateTableWithData`:
+        def `test_creates_a_table_from_domain_and_list`:
+            a: null
+            mf: null
+            b: null
+            y: null
+            abc: null
+            ?: null
+            m: null
+            c: null
+        def `test_creates_a_table_from_domain_and_list_and_weights`:
+            a: null
+            mf: null
+            b: null
+            y: null
+            abc: null
+            ?: null
+            m: null
+            c: null
+        def `test_creates_a_table_from_domain_and_list_and_metas`:
+            Meta 1: null
+            XYZ: null
+            Meta 2: null
+            Meta 3: null
+            a: null
+            mf: null
+            b: null
+            y: null
+            abc: null
+            X: null
+            bb: null
+            ?: null
+            Y: null
+            aa: null
+            m: null
+            Z: null
+            c: null
+        def `test_creates_a_table_from_list_of_instances`:
+            iris: null
+        def `test_creates_a_table_from_list_of_instances_with_metas`:
+            zoo: null
+        def `test_creates_a_discrete_class_if_Y_has_few_distinct_values`:
+            v1: null
+            v2: null
+        def `test_calling_new_with_domain_and_numpy_arrays_calls_new_from_numpy`:
+            Orange.data.table.Table.from_numpy: null
+    class `CreateTableWithDomainAndTable`:
+        def `test_transform`:
+            x: null
+        def `test_transform_same_domain`:
+            iris: null
+        def `test_can_filter_row_with_slice_from_table_rows`:
+            convert: null
+        def `test_can_filter_row_with_slice_from_table`:
+            Orange.data.table._FromTableConversion: null
+        def `test_from_table_with_boolean_row_filter`:
+            from_table_rows: null
+            new: null
+        def `test_from_table_sparse_move_some_to_empty_metas`:
+            iris: null
+        def `test_from_table_sparse_move_all_to_empty_metas`:
+            iris: null
+        def `test_from_table_sparse_move_to_nonempty_metas`:
+            brown-selected: null
+        def `test_from_table_partwise`:
+            sum_x: null
+            sum_y: null
+            sum_metas: null
+            def `long_table`:
+                abcdef: null
+        def `test_from_table_shared_compute_value`:
+            iris: null
+        def `test_attributes_copied`:
+            A: null
+            Test: null
+            B: null
+            Changed: null
+    class `InterfaceTest`:
+        Continuous Feature 1: null
+        Continuous Feature 2: null
+        Discrete Feature 1: null
+        0: null
+        1: null
+        Discrete Feature 2: null
+        value1: null
+        value2: null
+        Continuous Class: null
+        Discrete Class: null
+        m: null
+        f: null
+    class `TestRowInstance`:
+        def `test_assignment`:
+            zoo: null
+            mammal: null
+            fish: null
+            Foo: null
+        def `test_iteration_with_assignment`:
+            iris: null
+    class `TestTableTranspose`:
+        def `test_transpose_no_class`:
+            c1: null
+            c2: null
+            Feature 1: null
+            Feature 2: null
+            Feature 3: null
+            Feature 4: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_discrete_class`:
+            c1: null
+            c2: null
+            cls: null
+            a: null
+            b: null
+            Feature 1: null
+            Feature 2: null
+            Feature 3: null
+            Feature 4: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_continuous_class`:
+            c1: null
+            c2: null
+            cls: null
+            Feature 1: null
+            Feature 2: null
+            Feature 3: null
+            Feature 4: null
+            4: null
+            3: null
+            2: null
+            1: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_missing_class`:
+            c1: null
+            c2: null
+            cls: null
+            Feature 1: null
+            Feature 2: null
+            Feature 3: null
+            Feature 4: null
+            3: null
+            2: null
+            1: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_multiple_class`:
+            c1: null
+            c2: null
+            cls1: null
+            cls2: null
+            Feature 1: null
+            Feature 2: null
+            Feature 3: null
+            Feature 4: null
+            0: null
+            1: null
+            2: null
+            3: null
+            4: null
+            5: null
+            6: null
+            7: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_metas`:
+            c1: null
+            c2: null
+            m1: null
+            aa: null
+            bb: null
+            cc: null
+            dd: null
+            Feature 1: null
+            Feature 2: null
+            Feature 3: null
+            Feature 4: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_discrete_metas`:
+            c1: null
+            c2: null
+            m1: null
+            aa: null
+            bb: null
+            Feature 1: null
+            Feature 2: null
+            Feature 3: null
+            Feature 4: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_continuous_metas`:
+            c1: null
+            c2: null
+            m1: null
+            Feature 1: null
+            Feature 2: null
+            Feature 3: null
+            Feature 4: null
+            0: null
+            1: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_missing_metas`:
+            c1: null
+            c2: null
+            m1: null
+            aa: null
+            bb: null
+            dd: null
+            Feature 1: null
+            Feature 2: null
+            Feature 3: null
+            Feature 4: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_multiple_metas`:
+            c1: null
+            c2: null
+            m1: null
+            m2: null
+            aa: null
+            aaa: null
+            bb: null
+            bbb: null
+            cc: null
+            ccc: null
+            dd: null
+            ddd: null
+            Feature 1: null
+            Feature 2: null
+            Feature 3: null
+            Feature 4: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_class_and_metas`:
+            c1: null
+            c2: null
+            m1: null
+            m2: null
+            cls: null
+            aa: null
+            aaa: null
+            bb: null
+            bbb: null
+            cc: null
+            ccc: null
+            dd: null
+            ddd: null
+            Feature 1: null
+            Feature 2: null
+            Feature 3: null
+            Feature 4: null
+            1: null
+            2: null
+            3: null
+            4: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_attributes_of_attributes_discrete`:
+            c1: null
+            c2: null
+            attr1: null
+            a: null
+            attr2: null
+            aa: null
+            b: null
+            bb: null
+            Feature 1: null
+            Feature 2: null
+            Feature 3: null
+            Feature 4: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_attributes_of_attributes_continuous`:
+            c1: null
+            c2: null
+            attr1: null
+            1.1: null
+            attr2: null
+            1.3: null
+            2.2: null
+            2.3: null
+            Feature 1: null
+            Feature 2: null
+            Feature 3: null
+            Feature 4: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_attributes_of_attributes_missings`:
+            c1: null
+            c2: null
+            attr1: null
+            a: null
+            attr2: null
+            aa: null
+            b: null
+            Feature 1: null
+            Feature 2: null
+            Feature 3: null
+            Feature 4: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_class_metas_attributes`:
+            c1: null
+            c2: null
+            attr1: null
+            a1: null
+            attr2: null
+            aa1: null
+            b1: null
+            bb1: null
+            m1: null
+            m2: null
+            cls: null
+            aa: null
+            aaa: null
+            bb: null
+            bbb: null
+            cc: null
+            ccc: null
+            dd: null
+            ddd: null
+            Feature 1: null
+            Feature 2: null
+            Feature 3: null
+            Feature 4: null
+            1: null
+            2: null
+            3: null
+            4: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_duplicate_feature_names`:
+            iris: null
+        def `test_transpose`:
+            zoo: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_callback`:
+            zoo: null
+        def `test_transpose_no_class_remove_inst`:
+            c1: null
+            c2: null
+            1: null
+            3: null
+            5: null
+            7: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_discrete_class_remove_inst`:
+            c1: null
+            c2: null
+            cls: null
+            a: null
+            b: null
+            1: null
+            3: null
+            5: null
+            7: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_continuous_class_remove_inst`:
+            c1: null
+            c2: null
+            cls: null
+            1: null
+            3: null
+            5: null
+            7: null
+            4: null
+            2: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_missing_class_remove_inst`:
+            c1: null
+            c2: null
+            cls: null
+            1: null
+            3: null
+            5: null
+            7: null
+            2: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_multiple_class_remove_inst`:
+            c1: null
+            c2: null
+            cls1: null
+            cls2: null
+            1: null
+            3: null
+            5: null
+            7: null
+            0: null
+            2: null
+            4: null
+            6: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_metas_remove_inst`:
+            c1: null
+            c2: null
+            m1: null
+            aa: null
+            bb: null
+            cc: null
+            dd: null
+            1: null
+            3: null
+            5: null
+            7: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_discrete_metas_remove_inst`:
+            c1: null
+            c2: null
+            m1: null
+            aa: null
+            bb: null
+            1: null
+            3: null
+            5: null
+            7: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_continuous_metas_remove_inst`:
+            c1: null
+            c2: null
+            m1: null
+            1: null
+            3: null
+            5: null
+            7: null
+            0: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_missing_metas_remove_inst`:
+            c1: null
+            c2: null
+            m1: null
+            aa: null
+            bb: null
+            dd: null
+            1: null
+            3: null
+            5: null
+            7: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_multiple_metas_remove_inst`:
+            c1: null
+            c2: null
+            m1: null
+            m2: null
+            aa: null
+            aaa: null
+            bb: null
+            bbb: null
+            cc: null
+            ccc: null
+            dd: null
+            ddd: null
+            1: null
+            3: null
+            5: null
+            7: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_class_and_metas_remove_inst`:
+            c1: null
+            c2: null
+            m1: null
+            m2: null
+            cls: null
+            aa: null
+            aaa: null
+            bb: null
+            bbb: null
+            cc: null
+            ccc: null
+            dd: null
+            ddd: null
+            1: null
+            3: null
+            5: null
+            7: null
+            2: null
+            4: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_attributes_of_attributes_discrete_remove_inst`:
+            c1: null
+            c2: null
+            attr1: null
+            a: null
+            attr2: null
+            aa: null
+            b: null
+            bb: null
+            1: null
+            3: null
+            5: null
+            7: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_attributes_of_attributes_continuous_remove_inst`:
+            c1: null
+            c2: null
+            attr1: null
+            1.1: null
+            attr2: null
+            1.3: null
+            2.2: null
+            2.3: null
+            1: null
+            3: null
+            5: null
+            7: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_attributes_of_attributes_missings_remove_inst`:
+            c1: null
+            c2: null
+            attr1: null
+            a: null
+            attr2: null
+            aa: null
+            b: null
+            0: null
+            2: null
+            4: null
+            6: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_class_metas_attributes_remove_inst`:
+            c1: null
+            c2: null
+            attr1: null
+            a1: null
+            attr2: null
+            aa1: null
+            b1: null
+            bb1: null
+            m1: null
+            m2: null
+            cls: null
+            aa: null
+            aaa: null
+            bb: null
+            bbb: null
+            cc: null
+            ccc: null
+            dd: null
+            ddd: null
+            1: null
+            3: null
+            5: null
+            7: null
+            2: null
+            4: null
+            Feature name: Ime spremenljivke
+        def `test_transpose_name`:
+            iris: null
+    class `TestTableSparseDense`:
+        def `setUp`:
+            iris: null
+        def `test_sparse_dense_transformation`:
+            iris: null
+        def `test_from_table_add_one_sparse_column`:
+            S1: null
+        def `test_from_table_add_lots_of_sparse_columns`:
+            S: null
+        def `test_from_table_replace_attrs_with_sparse`:
+            S1: null
+        def `test_from_table_sparse_metas`:
+            S1: null
+        def `test_from_table_sparse_metas_with_strings`:
+            text: null
+            S: null
+    class `ConcurrencyTests`:
+        def `test_from_table_non_blocking`:
+            iris: null
+            a: null
+    class `EfficientTransformTests`:
+        def `setUp`:
+            iris: null
+    __main__: null
+tests/test_third_party.py:
+    class `TestPkgResources`:
+        def `test_parse_version`:
+            3.4.1: null
+            3.4.0: null
+            3.4.dev: null
+            3.4.1.dev: null
+            3.4.2.dev: null
+tests/test_transformation.py:
+    class `TestTransformation`:
+        def `setUpClass`:
+            zoo: null
+        def `test_pickling_target_domain`:
+            _target_domain: null
+    class `IdentityTest`:
+        def `test_identity`:
+            X: null
+            C: null
+            0: null
+            1: null
+            2: null
+            S: null
+            A: null
+            B: null
+            D: null
+        def `test_eq_and_hash`:
+            x: null
+            y: null
+tests/test_tree.py:
+    class `TestSklTreeLearner`:
+        def `test_classification`:
+            iris: null
+        def `test_regression`:
+            housing: null
+    class `TestTreeLearner`:
+        def `test_uses_preprocessors`:
+            iris: null
+    class `TestDecisionTreeClassifier`:
+        def `setUpClass`:
+            iris: null
+        def `test_criterion`:
+            entropy: null
+        def `test_splitter`:
+            random: null
+tests/test_txt_reader.py:
+    '\
+Feature 1\tFeature 2\tFeature 3
+1.0      \t1.3        \t5
+2.0      \t42        \t7
+': null
+    '\
+Feature 1,   Feature 2,Feature 3
+1.0,      1.3,       5
+2.0,      42,        7
+': null
+    '\
+1.0      \t1.3        \t5
+2.0      \t42        \t7
+': null
+    '\
+1.0,      1.3,       5
+2.0,      42,        7
+': null
+    '\
+a,b
+d,c
+,
+e,1
+f,g
+': null
+    '\
+A,B
+1,A
+2,B
+3,A
+?,B
+5,?
+': null
+    class `TestTabReader`:
+        def `read_easy`:
+            wt: null
+            1: null
+            2: null
+            3: null
+        def `test_read_tab`:
+            'Feature ': null
+        def `test_read_csv`:
+            'Feature ': null
+        def `test_read_nonutf8_encoding`:
+            datasets/binary-blob.tab: null
+            NUL: null
+            error: null
+            datasets/invalid_characters.tab: null
+        def `test_noncontinous_marked_continuous`:
+            wt: null
+            line 5, column 2: null
+        def `test_pr1734`:
+            foo: null
+            wt: null
+            '\
+foo
+time
+
+123123123
+': null
+        def `test_csv_sniffer`:
+            datasets/test_asn_data_working.csv: null
+tests/test_url_reader.py:
+    class `TestUrlReader`:
+        def `test_basic_file`:
+            https://datasets.biolab.si/core/titanic.tab: null
+            https://datasets.biolab.si/core/grades.xlsx: null
+        def `test_zipped`:
+            http://datasets.biolab.si/core/philadelphia-crime.csv.xz: null
+        def `test_special_characters`:
+            http://file.biolab.si/text-semantics/data/elektrotehniski-: null
+            vestnik-clanki/detektiranje-utrdb-v-šahu-.txt: null
+        def `test_base_url_with_query`:
+            https://datasets.biolab.si/core/grades.xlsx?a=1&b=2: null
+        def `test_url_with_fragment`:
+            https://datasets.biolab.si/core/grades.xlsx#tab=1: null
+        def `test_special_characters_with_query_and_fragment`:
+            http://file.biolab.si/text-semantics/data/elektrotehniski-: null
+            vestnik-clanki/detektiranje-utrdb-v-šahu-.txt?a=1&b=2#c=3: null
+    __main__: null
+tests/test_util.py:
+    class `TestUtil`:
+        def `test_get_entry_point`:
+            Orange3: null
+            gui_scripts: null
+            orange-canvas: null
+        def `test_export_globals`:
+            SOMETHING: null
+            TestUtil: null
+        def `test_deprecated`:
+            deprecated: null
+            identity: null
+        def `test_reprable`:
+            x: null
+            \n: null
+            ' ': null
+            ReplaceUnknownsRandom(: null
+            variable=ContinuousVariable(name='x',number_of_decimals=3),: null
+            distribution=Continuous([[0.],[0.]])): null
+            LogisticRegressionLearner(): null
+        def `test_deepgetattr`:
+            l.__len__.__call__: null
+            l.__nx__.__x__: null
+        def `test_nan_eq`:
+            nan: null
+            inf: null
+        def `test_nan_hash_stand`:
+            nan: null
+        def `test_vstack`:
+            dense: null
+            sparse: null
+        def `test_hstack`:
+            dense: null
+            sparse: null
+        def `assertCorrectArrayType`:
+            dense: null
+            sparse: null
+        def `test_raise_deprecations`:
+            ORANGE_DEPRECATIONS_ERROR: null
+            ORANGE_DEPRECATIONS_ERROR not set: null
+            foo: null
+        def `test_stats_sparse`:
+            iris: null
+        def `test_csc_array_equal`:
+            ignore: null
+            .*: null
+    __main__: null
+tests/test_value.py:
+    class `TestValue`:
+        def `test_pickling_discrete_values`:
+            iris: null
+        def `test_pickling_string_values`:
+            zoo: null
+            name: null
+        def `test_compare_continuous`:
+            housing: null
+            MEDV: null
+        def `test_compare_discrete`:
+            G: null
+            M: null
+            F: null
+        def `test_compare_string`:
+            zoo: null
+            name: null
+            aardvark: null
+        def `test_hash`:
+            var: null
+            test: null
+            red: null
+            green: null
+            blue: null
+        def `test_as_values`:
+            x: null
+            s: null
+            a: null
+            b: null
+tests/test_xlsx_reader.py:
+    def `get_dataset`:
+        xlsx_files: null
+    def `get_xlsx_reader`:
+        .xlsx: null
+    def `get_xls_reader`:
+        .xls: null
+    class `TestExcelReader`:
+        def `test_read_round_floats`:
+            round_floats: null
+            1: null
+            2: null
+        def `test_write_file`:
+            .xlsx: null
+            zoo: null
+    class `TestExcelHeader0`:
+        def `test_read`:
+            header_0: null
+            Feature {}: null
+    class `TextExcelSheets`:
+        def `test_sheets`:
+            header_0_sheet: null
+            Sheet1: null
+            my_sheet: null
+            Sheet3: null
+        def `test_named_sheet`:
+            header_0_sheet: null
+            my_sheet: null
+            header_0_sheet-my_sheet: null
+        def `test_named_sheet_table_xlsx`:
+            header_0_sheet.xlsx: null
+            my_sheet: null
+            header_0_sheet-my_sheet: null
+        def `test_named_sheet_table_xls`:
+            header_0_sheet.xls: null
+            my_sheet: null
+            header_0_sheet-my_sheet: null
+    class `TestExcelHeader1`:
+        def `test_no_flags`:
+            header_1_no_flags: null
+            green: null
+            red: null
+        def `test_flags`:
+            header_1_flags: null
+            d: null
+            b: null
+            acf: null
+            green: null
+            red: null
+    class `TestExcelHeader3`:
+        def `test_read`:
+            header_3: null
+            d: null
+            g: null
+            nan: null
+            b: null
+            acf: null
+            green: null
+            red: null
+            abcdefghijklmnopqrstuvw: null
+    class `TestMissingValues`:
+        def `test_read_errors`:
+            missing: null
+            C: null
+    __main__: null
+tests/sql/test_filter.py:
+    class `TestIsDefinedSql`:
+        def `setUpDB`:
+            m: null
+            f: null
+        def `test_on_all_columns`:
+            postgres: null
+            mssql: null
+        def `test_selected_columns`:
+            postgres: null
+            mssql: null
+        def `test_all_columns_negated`:
+            postgres: null
+        def `test_selected_columns_negated`:
+            postgres: null
+            mssql: null
+        def `test_can_inherit_is_defined_filter`:
+            postgres: null
+    class `TestHasClass`:
+        def `setUpDB`:
+            m: null
+            f: null
+        def `test_has_class`:
+            postgres: null
+            mssql: null
+        def `test_negated`:
+            postgres: null
+            mssql: null
+    class `TestSameValueSql`:
+        def `setUpDB`:
+            a: null
+            m: null
+            f: null
+            b: null
+        def `test_on_continuous_attribute`:
+            postgres: null
+            mssql: null
+        def `test_on_continuous_attribute_with_unknowns`:
+            postgres: null
+            mssql: null
+        def `test_on_continuous_attribute_with_unknown_value`:
+            postgres: null
+            mssql: null
+        def `test_on_continuous_attribute_negated`:
+            postgres: null
+        def `test_on_discrete_attribute`:
+            postgres: null
+            mssql: null
+            a: null
+        def `test_on_discrete_attribute_with_unknown_value`:
+            postgres: null
+            mssql: null
+        def `test_on_discrete_attribute_with_unknowns`:
+            postgres: null
+            mssql: null
+            m: null
+        def `test_on_discrete_attribute_negated`:
+            postgres: null
+            mssql: null
+            a: null
+        def `test_on_discrete_attribute_value_passed_as_int`:
+            postgres: null
+            mssql: null
+        def `test_on_discrete_attribute_value_passed_as_float`:
+            postgres: null
+            mssql: null
+    class `TestValuesSql`:
+        def `setUpDB`:
+            a: null
+            m: null
+            f: null
+            b: null
+        def `test_values_filter_with_no_conditions`:
+            postgres: null
+            mssql: null
+        def `test_discrete_value_filter`:
+            postgres: null
+            mssql: null
+            a: null
+        def `test_discrete_value_filter_with_multiple_values`:
+            postgres: null
+            a: null
+            b: null
+        def `test_discrete_value_filter_with_None`:
+            postgres: null
+        def `test_continuous_value_filter_equal`:
+            postgres: null
+            mssql: null
+        def `test_continuous_value_filter_not_equal`:
+            postgres: null
+        def `test_continuous_value_filter_less`:
+            postgres: null
+            mssql: null
+        def `test_continuous_value_filter_less_equal`:
+            postgres: null
+        def `test_continuous_value_filter_greater`:
+            postgres: null
+        def `test_continuous_value_filter_greater_equal`:
+            postgres: null
+        def `test_continuous_value_filter_between`:
+            postgres: null
+        def `test_continuous_value_filter_outside`:
+            postgres: null
+            mssql: null
+        def `test_continuous_value_filter_isdefined`:
+            postgres: null
+    class `TestFilterStringSql`:
+        def `setUpDB`:
+            Lorem ipsum dolor sit amet, consectetur adipiscing: null
+            elit. Vestibulum vel dolor nulla. Etiam elit lectus, mollis nec: null
+            mattis sed, pellentesque in turpis. Vivamus non nisi dolor. Etiam: null
+            lacinia dictum purus, in ullamcorper ante vulputate sed. Nullam: null
+            congue blandit elementum. Donec blandit laoreet posuere. Proin: null
+            quis augue eget tortor posuere mollis. Fusce vestibulum bibendum: null
+            neque at convallis. Donec iaculis risus volutpat malesuada: null
+            vehicula. Ut cursus tempor massa vulputate lacinia. Pellentesque: null
+            eu tortor sed diam placerat porttitor et volutpat risus. In: null
+            vulputate rutrum lacus ac sagittis. Suspendisse interdum luctus: null
+            sem auctor commodo.: null
+            ' ': null
+        def `test_filter_string_is_defined`:
+            postgres: null
+        def `test_filter_string_equal`:
+            postgres: null
+            mssql: null
+            in: null
+        def `test_filter_string_equal_case_insensitive_value`:
+            postgres: null
+            In: null
+            in: null
+        def `test_filter_string_equal_case_insensitive_data`:
+            postgres: null
+            donec: null
+            Donec: null
+        def `test_filter_string_not_equal`:
+            postgres: null
+            in: null
+        def `test_filter_string_not_equal_case_insensitive_value`:
+            postgres: null
+            In: null
+            in: null
+        def `test_filter_string_not_equal_case_insensitive_data`:
+            postgres: null
+            donec: null
+            Donec: null
+        def `test_filter_string_less`:
+            postgres: null
+            mssql: null
+            A: null
+        def `test_filter_string_less_case_insensitive_value`:
+            postgres: null
+            In: null
+            in: null
+        def `test_filter_string_less_case_insensitive_data`:
+            postgres: null
+            donec: null
+        def `test_filter_string_less_equal`:
+            postgres: null
+            mssql: null
+            A: null
+        def `test_filter_string_less_equal_case_insensitive_value`:
+            postgres: null
+            In: null
+            in: null
+        def `test_filter_string_less_equal_case_insensitive_data`:
+            postgres: null
+            donec: null
+        def `test_filter_string_greater`:
+            postgres: null
+            mssql: null
+            volutpat: null
+        def `test_filter_string_greater_case_insensitive_value`:
+            postgres: null
+            In: null
+            in: null
+        def `test_filter_string_greater_case_insensitive_data`:
+            postgres: null
+            donec: null
+        def `test_filter_string_greater_equal`:
+            postgres: null
+            volutpat: null
+        def `test_filter_string_greater_equal_case_insensitive_value`:
+            postgres: null
+            In: null
+            in: null
+        def `test_filter_string_greater_equal_case_insensitive_data`:
+            postgres: null
+            donec: null
+        def `test_filter_string_between`:
+            postgres: null
+            a: null
+            c: null
+        def `test_filter_string_between_case_insensitive_value`:
+            postgres: null
+            I: null
+            O: null
+            i: null
+            o: null
+        def `test_filter_string_between_case_insensitive_data`:
+            postgres: null
+            i: null
+            O: null
+            o: null
+        def `test_filter_string_contains`:
+            postgres: null
+            et: null
+        def `test_filter_string_contains_case_insensitive_value`:
+            postgres: null
+            eT: null
+            et: null
+        def `test_filter_string_contains_case_insensitive_data`:
+            postgres: null
+            do: null
+        def `test_filter_string_outside`:
+            postgres: null
+            am: null
+            di: null
+        def `test_filter_string_outside_case_insensitive`:
+            postgres: null
+            d: null
+            k: null
+        def `test_filter_string_starts_with`:
+            postgres: null
+            D: null
+        def `test_filter_string_starts_with_case_insensitive`:
+            postgres: null
+            D: null
+            d: null
+        def `test_filter_string_ends_with`:
+            postgres: null
+            s: null
+        def `test_filter_string_ends_with_case_insensitive`:
+            postgres: null
+            S: null
+            s: null
+        def `test_filter_string_list`:
+            postgres: null
+            et: null
+            in: null
+        def `test_filter_string_list_case_insensitive_value`:
+            postgres: null
+            Et: null
+            In: null
+            et: null
+            in: null
+        def `test_filter_string_list_case_insensitive_data`:
+            postgres: null
+            mssql: null
+            donec: null
+            Donec: null
+    __main__: null
+tests/sql/test_misc.py:
+    class `MiscSqlTests`:
+        def `test_discretization`:
+            postgres: null
+            sepal length: null
+        def `test_get_conditional_distribution`:
+            postgres: null
+            Cannot import widgets: null
+            sepal length: null
+        def `test_create_sql_contingency`:
+            postgres: null
+            Cannot import widgets: null
+tests/sql/test_naive_bayes_sql.py:
+    class `NaiveBayesTest`:
+        def `test_NaiveBayes`:
+            postgres: null
+            Iris-setosa: null
+            Iris-virginica: null
+            Iris-versicolor: null
+            iris: null
+tests/sql/test_sql_table.py:
+    class `TestSqlTable`:
+        def `discrete_variable`:
+            mf: null
+        def `test_constructs_correct_attributes`:
+            postgres: null
+            col0: null
+            '"col0"': null
+            col1: null
+            '"col1"': null
+            f: null
+            m: null
+            col2: null
+            '"col2"': null
+        def `test_make_attributes`:
+            postgres: null
+        def `test_len`:
+            postgres: null
+            mssql: null
+        def `test_bool`:
+            postgres: null
+            mssql: null
+        def `test_len_with_filter`:
+            postgres: null
+            mssql: null
+            m: null
+            x: null
+        def `test_XY_small`:
+            postgres: null
+            mssql: null
+            col2: null
+            0: null
+            1: null
+            2: null
+        def `test_XY_large`:
+            postgres: null
+            mssql: null
+            Orange.data.sql.table.AUTO_DL_LIMIT: null
+            col2: null
+            0: null
+            1: null
+            2: null
+        def `test_download_data`:
+            postgres: null
+            mssql: null
+            X: null
+            Y: null
+            metas: null
+            W: null
+            ids: null
+            col2: null
+            0: null
+            1: null
+            2: null
+        def `test_query_all`:
+            postgres: null
+            mssql: null
+        def `test_unavailable_row`:
+            postgres: null
+            mssql: null
+        def `test_query_subset_of_attributes`:
+            postgres: null
+            mssql: null
+            sepal length: null
+            sepal width: null
+            double width: null
+            2 * "sepal width": null
+        def `test_query_subset_of_rows`:
+            postgres: null
+        def `test_getitem_single_value`:
+            postgres: null
+            mssql: null
+            Iris-setosa: null
+        def `test_type_hints`:
+            postgres: null
+            mssql: null
+            iris: null
+        def `test_joins`:
+            postgres: null
+            "SELECT a.""sepal length"",
+                          b. ""petal length"",
+                          CASE WHEN b.""petal length"" < 3 THEN '<'
+                               ELSE '>'
+                           END AS ""qualitative petal length""
+                     FROM iris a
+               INNER JOIN iris b ON a.""sepal width"" = b.""sepal width""
+                    WHERE a.""petal width"" < 1
+                 ORDER BY a.""sepal length"", b. ""petal length"" ASC": null
+            qualitative petal length: null
+            <: null
+            >: null
+        def `_mock_attribute`:
+            '"%s"': null
+        def `test_universal_table`:
+            postgres: null
+            '
+            SELECT
+                v1.col2 as v1,
+                v2.col2 as v2,
+                v3.col2 as v3,
+                v4.col2 as v4,
+                v5.col2 as v5
+              FROM %(table_name)s v1
+        INNER JOIN %(table_name)s v2 ON v2.col0 = v1.col0 AND v2.col1 = 2
+        INNER JOIN %(table_name)s v3 ON v3.col0 = v2.col0 AND v3.col1 = 3
+        INNER JOIN %(table_name)s v4 ON v4.col0 = v1.col0 AND v4.col1 = 4
+        INNER JOIN %(table_name)s v5 ON v5.col0 = v1.col0 AND v5.col1 = 5
+             WHERE v1.col1 = 1
+          ORDER BY v1.col0
+        ': null
+            '"%s"': null
+        iris: null
+        Iris-setosa: null
+        Iris-virginica: null
+        Iris-versicolor: null
+        def `test_class_var_type_hints`:
+            postgres: null
+            mssql: null
+            iris: null
+        def `test_meta_type_hints`:
+            postgres: null
+            mssql: null
+            iris: null
+        def `test_metas_type_hints`:
+            postgres: null
+            mssql: null
+            iris: null
+        def `test_select_all`:
+            postgres: null
+            mssql: null
+            SELECT * FROM iris: null
+        def `test_discrete_bigint`:
+            postgres: null
+            bigint: null
+        def `test_continous_bigint`:
+            postgres: null
+            mssql: null
+            bigint: null
+        def `test_discrete_int`:
+            postgres: null
+            int: null
+        def `test_continous_int`:
+            postgres: null
+            mssql: null
+            int: null
+        def `test_discrete_smallint`:
+            postgres: null
+            smallint: null
+        def `test_continous_smallint`:
+            postgres: null
+            mssql: null
+            smallint: null
+        def `test_boolean`:
+            postgres: null
+            F: null
+            T: null
+            False: null
+            True: null
+            boolean: null
+        def `test_discrete_char`:
+            postgres: null
+            mssql: null
+            M: null
+            F: null
+            char(1): null
+        def `test_discrete_bigger_char`:
+            postgres: null
+            M: null
+            F: null
+            char(10): null
+        def `test_meta_char`:
+            postgres: null
+            mssql: null
+            ABCDEFGHIJKLMNOPQRSTUVW: null
+            char(1): null
+        def `test_discrete_varchar`:
+            postgres: null
+            mssql: null
+            M: null
+            F: null
+            varchar(1): null
+        def `test_meta_varchar`:
+            postgres: null
+            mssql: null
+            ABCDEFGHIJKLMNOPQRSTUVW: null
+            varchar(1): null
+        def `test_time_date`:
+            postgres: null
+            2014-04-12: null
+            2014-04-13: null
+            2014-04-14: null
+            2014-04-15: null
+            2014-04-16: null
+            date: null
+        def `test_time_time`:
+            postgres: null
+            17:39:51: null
+            11:51:48.46: null
+            05:20:21.492149: null
+            21:47:06: null
+            04:47:35.8: null
+            time: null
+        def `test_time_timetz`:
+            postgres: null
+            17:39:51+0200: null
+            11:51:48.46+01: null
+            05:20:21.4921: null
+            21:47:06-0600: null
+            04:47:35.8+0330: null
+            timetz: null
+        def `test_time_timestamp`:
+            postgres: null
+            2014-07-15 17:39:51.348149: null
+            2008-10-05 11:51:48.468149: null
+            2008-11-03 05:20:21.492149: null
+            2015-01-02 21:47:06.228149: null
+            2016-04-16 04:47:35.892149: null
+            timestamp: null
+        def `test_time_timestamptz`:
+            postgres: null
+            2014-07-15 17:39:51.348149+0200: null
+            2008-10-05 11:51:48.468149+02: null
+            2008-11-03 05:20:21.492149+01: null
+            2015-01-02 21:47:06.228149+0100: null
+            2016-04-16 04:47:35.892149+0330: null
+            timestamptz: null
+        def `test_double_precision`:
+            postgres: null
+            mssql: null
+            double precision: null
+        def `test_numeric`:
+            postgres: null
+            mssql: null
+            numeric(15, 2): null
+        def `test_real`:
+            postgres: null
+            mssql: null
+            real: null
+        def `test_serial`:
+            postgres: null
+            serial: null
+        def `test_smallserial`:
+            postgres>90200: null
+            smallserial: null
+        def `test_bigserial`:
+            postgres>90200: null
+            bigserial: null
+        def `test_text`:
+            postgres: null
+            ABCDEFGHIJKLMNOPQRSTUVW: null
+            text: null
+        def `test_other`:
+            postgres: null
+            bcd4d9c0-361e-bad4-7ceb-0d171cdec981: null
+            544b7ddc-d861-0201-81c8-9f7ad0bbf531: null
+            b35a10f7-7901-f313-ec16-5ad9778040a6: null
+            b267c4be-4a26-60b5-e664-737a90a40e93: null
+            uuid: null
+            foo: null
+        def `test_recovers_connection_after_sql_error`:
+            postgres: null
+            mssql: null
+            SELECT 1/%s FROM %s: null
+            SELECT %s FROM %s: null
+        def `test_basic_stats`:
+            postgres: null
+            sepal length: null
+        def `test_basic_stats_on_large_data`:
+            postgres: null
+            Orange.data.sql.table.LARGE_TABLE: null
+            sepal length: null
+        def `test_distributions`:
+            postgres: null
+            mssql: null
+        def `test_contingencies`:
+            postgres: null
+            sepal width: null
+            iris: null
+        def `test_pickling_restores_connection_pool`:
+            postgres: null
+        def `test_list_tables_with_schema`:
+            postgres: null
+            DROP SCHEMA IF EXISTS orange_tests CASCADE: null
+            CREATE SCHEMA orange_tests: null
+            CREATE TABLE orange_tests.efgh (id int): null
+            INSERT INTO orange_tests.efgh (id) VALUES (1): null
+            INSERT INTO orange_tests.efgh (id) VALUES (2): null
+            orange_tests: null
+            efgh: null
+        def `test_nan_frequency`:
+            postgres: null
+            mssql: null
+    __main__: null
+widgets/data/tests/test_owaggregatecolumns.py:
+    class `TestOWAggregateColumn`:
+        def `setUp`:
+            c1 c2 c3: null
+            t1 t2: null
+            a: null
+            b: null
+            c: null
+            d1 d2 d3: null
+            s1: null
+            foo: null
+            bar: null
+            c4: null
+        def `test_no_input`:
+            c1 c2 t2: null
+        def `test_compute_data`:
+            c1 c2 t2: null
+            Sum: Vsota
+            Max: null
+        def `test_var_name`:
+            test: null
+            d1: null
+        def `test_var_types`:
+            t1 c2 t2: null
+            t1 t2: null
+            Min: null
+            Max: null
+            Mean: null
+            Median: null
+        def `test_operations`:
+            c1 c2 t2: null
+            Sum: Vsota
+            Product: Produkt
+            Min: null
+            Max: null
+            Mean: null
+            Variance: Varianca
+            Median: Mediana
+            error in '{self.widget.operation}': null
+        def `test_operations_with_nan`:
+            c1 c2 t2: null
+            Sum: Vsota
+            Product: Produkt
+            Min: null
+            Max: null
+            Mean: null
+            Variance: Varianca
+            Median: Mediana
+            error in '{self.widget.operation}': null
+        def `test_contexts`:
+            c1 c2 t2: null
+        def `test_features_signal`:
+            c1 c2 t1: null
+            c1 t2: null
+            agg: null
+            c1 t2 d1: null
+            foo: null
+            d1 d2: null
+        def `test_selection_radios`:
+            c1 t2: null
+            agg: null
+        def `test_operation_changed`:
+            agg: null
+            Max: null
+        def `test_and_others`:
+            "'c1'": null
+            "'c1', 'c2', 'd1', 'd2', 't1' and 'd3'": "'c1', 'c2', 'd1', 'd2', 't1' in 'd3'"
+            "'c1', 'c2', 'd1', 'd2', 't1' and 1 more": "'c1', 'c2', 'd1', 'd2', 't1' in še 1 druga"
+            "'c1', 'c2' and 4 more": "'c1', 'c2' in še 4 druge"
+        def `test_missing`:
+            "'{attrs[0].name}'": null
+            "'{attrs[0].name}' and '{attrs[1].name}'": "'{attrs[0].name}' in '{attrs[1].name}'"
+        def `test_report`:
+            c1 c2 t2: null
+            c{i:02}: null
+    __main__: null
+widgets/data/tests/test_owcolor.py:
+    class `AttrDescTest`:
+        def `test_name`:
+            x: null
+            y: null
+        def `test_no_compute_value`:
+            x: null
+        def `test_reset`:
+            x: null
+            y: null
+        def `test_to_dict`:
+            x: null
+            y: null
+            rename: null
+            foo: null
+    class `DiscAttrTest`:
+        def `setUp`:
+            x: null
+            a: null
+            b: null
+            c: null
+        def `test_values`:
+            a: null
+            b: null
+            c: null
+            d: null
+        def `test_create_variable`:
+            z: null
+            d: null
+            a: null
+            c: null
+            palette: null
+        def `test_reset`:
+            d: null
+        def `test_to_dict`:
+            y: null
+            rename: null
+            b2: null
+            renamed_values: null
+            b: null
+            colors: null
+            a: null
+            '#010203': null
+            c: null
+            '#020304': null
+            d: null
+            x: null
+            '#123456': null
+        def `test_from_dict_coliding_values`:
+            renamed_values: null
+            a: null
+            b: null
+            duplicate names: podvojenih imen
+            c: null
+            e: null
+        def `test_from_dict_exceptions`:
+            rename: null
+            colors: null
+            a: null
+            '#000000': null
+            '#00': null
+            '#qwerty': null
+            renamed_values: null
+    class `ContAttrDescTest`:
+        def `setUp`:
+            x: null
+        def `test_palette`:
+            foo: null
+        def `test_create_variable`:
+            z: null
+            colors: null
+        def `test_to_dict`:
+            x: null
+            y: null
+            rename: null
+            linear_viridis: null
+            colors: null
+        def `test_from_dict_exceptions`:
+            x: null
+            colors: null
+            no such palette: null
+    class `BaseTestColorTableModel`:
+        def `test_data`:
+            bar: null
+        def `test_set_data`:
+            foo: null
+    class `TestDiscColorTableModel`:
+        def `setUp`:
+            x: null
+            abc: null
+            y: null
+            def: null
+            z: null
+            ghijk: null
+        def `test_data`:
+            e: null
+            k: null
+            foo: null
+        def `test_set_data`:
+            k: null
+            foo: null
+            g: null
+            h: null
+            i: null
+            j: null
+    class `TestContColorTableModel`:
+        def `setUp`:
+            z: null
+            w: null
+            u: null
+        def `test_data`:
+            color_strip: null
+            Copy to all: Dodeli vsem
+        def `test_set_data`:
+            color_strip: null
+    class `TestColorStripDelegate`:
+        def `setUp`:
+            z: null
+            w: null
+            u: null
+        def `test_color_combo`:
+            closeEditor: null
+        def `test_paint`:
+            paint: null
+    class `TestOWColor`:
+        def `setUp`:
+            iris: null
+        def `test_invalid_input_colors`:
+            a: null
+            colors: null
+            invalid: null
+        def `test_unconditional_commit_on_new_signal`:
+            now: null
+        def `test_commit_on_data_changed`:
+            deferred: null
+            y: null
+        def `test_model_content`:
+            heart_disease: null
+        def `test_report`:
+            zoo: null
+        def `test_string_variables`:
+            zoo: null
+        def `test_changed_compute_value`:
+            x: null
+        def `test_reset`:
+            a: null
+            b: null
+        def `test_save`:
+            getSaveFileName: null
+            foo: null
+            bar: null
+        def `test_save_low`:
+            varA: null
+            abc: null
+            a2: null
+            varB: null
+            X: null
+            varC: null
+            c2: null
+            varD: null
+            linear_viridis: null
+            varE: null
+            foo.colors: null
+            categorical: null
+            rename: null
+            renamed_values: null
+            b: null
+            numeric: null
+            colors: null
+        def `test_load`:
+            Orange.widgets.data.owcolor.QMessageBox.critical: null
+            getOpenFileName: null
+            builtins.open: null
+            foo.colors: null
+            *.colors: null
+            json.load: null
+            err: null
+            d: null
+        def `test_load_ignore_warning`:
+            Orange.widgets.data.owcolor.QMessageBox.warning: null
+            foo: null
+            "'foo'": null
+            bar: null
+            "'foo' and 'bar'": "'foo' in 'bar'"
+            baz: null
+            "'foo', 'bar' and 'baz'": "'foo', 'bar' in 'baz'"
+            qux: null
+            "'foo', 'bar', 'baz' and 'qux'": "'foo', 'bar', 'baz' in 'qux'"
+            quux: null
+            "'foo', 'bar', 'baz', 'qux' and 'quux'": "'foo', 'bar', 'baz', 'qux' in 'quux'"
+            corge: null
+            "'foo', 'bar', 'baz', 'qux' and 2 other": "'foo', 'bar', 'baz', 'qux' in še dve drugi spremenljivki"
+            grault: null
+            "'foo', 'bar', 'baz', 'qux' and 3 other": "'foo', 'bar', 'baz', 'qux' in še tri druge spremenljivke"
+        def `_create_descs`:
+            var{c}: null
+            a: null
+            b: null
+            c: null
+            AB: null
+            CDE: null
+        def `test_parse_var_defs`:
+            categorical: null
+            varA: null
+            rename: null
+            a2: null
+            varB: null
+            renamed_values: null
+            b: null
+            X: null
+            numeric: null
+            varC: null
+            c2: null
+            varD: null
+            colors: null
+            linear_viridis: null
+            a: null
+            c: null
+        def `test_parse_var_defs_invalid`:
+            categorical: null
+            a: null
+            numeric: null
+            rename: null
+            b: null
+        def `test_parse_var_defs_shows_warnings`:
+            Orange.widgets.data.owcolor.QMessageBox.warning: null
+            categorical: null
+            varA: null
+            renamed_values: null
+            a: null
+            b: null
+            numeric: null
+            duplicate names: podvojenih imen
+        def `test_parse_var_defs_no_rename`:
+            Orange.widgets.data.owcolor.QMessageBox.warning: null
+            categorical: null
+            varA: null
+            rename: null
+            varB: null
+            numeric: null
+            duplicated names: podvojenih imen
+            X: null
+            varD: null
+    __main__: null
+widgets/data/tests/test_owconcatenate.py:
+    class `TestOWConcatenate`:
+        def `setUp`:
+            iris: null
+            titanic: null
+        def `test_source`:
+            Source ID: Vir
+            Source: Izvir
+            class_vars: null
+            attributes: null
+            metas: null
+            iris: null
+            titanic: null
+        def `test_source_ignore_compute_value`:
+            iris: null
+            titanic: null
+        def `test_unconditional_commit_on_new_signal`:
+            now: null
+        def `test_same_var_name`:
+            x: null
+            abcd: null
+            def: null
+        def `test_duplicated_id_column`:
+            x: null
+            abcd: null
+            x (1): null
+        def `test_domain_intersect`:
+            X1: null
+            X2: null
+            X3: null
+            a: null
+            b: null
+            D1: null
+            D2: null
+            D3: null
+            S1: null
+            S2: null
+        def `test_domain_union`:
+            X1: null
+            X2: null
+            X3: null
+            a: null
+            b: null
+            D1: null
+            D2: null
+            D3: null
+            S1: null
+            S2: null
+        def `test_domain_union_duplicated_names`:
+            X1: null
+            X2: null
+            X3: null
+            a: null
+            b: null
+            D1: null
+            S1: null
+            X1 (1): null
+            X2 (1): null
+            X2 (2): null
+            X1 (2): null
+        def `test_get_part_union`:
+            X1: null
+            X2: null
+            X3: null
+            X4: null
+            a: null
+            b: null
+            D1: null
+            D2: null
+            D3: null
+            S1: null
+            S2: null
+            S3: null
+            attributes: null
+            class_vars: null
+            metas: null
+        def `test_get_part_intersection`:
+            X1: null
+            X2: null
+            X3: null
+            X4: null
+            a: null
+            b: null
+            D1: null
+            D2: null
+            D3: null
+            S1: null
+            S2: null
+            S3: null
+            attributes: null
+            class_vars: null
+            metas: null
+        def `test_get_unique_vars`:
+            X1: null
+            X2: null
+            a: null
+            b: null
+            c: null
+            e: null
+            d: null
+            abc: null
+            ebd: null
+            abced: null
+        def `test_different_number_decimals`:
+            x: null
+    __main__: null
+widgets/data/tests/test_owcontinuize.py:
+    class `TestOWContinuize`:
+        def `test_empty_data`:
+            iris: null
+        def `test_continuous`:
+            housing: null
+        def `test_one_column_equal_values`:
+            iris: null
+        def `test_one_column_nan_values_normalize_sd`:
+            iris: null
+        def `test_one_column_nan_values_normalize_span`:
+            iris: null
+        def `test_disable_normalize_sparse`:
+            def `assert_enabled`:
+                Error in {method}: null
+            iris: null
+        def `test_normalizations`:
+            xyz: null
+    class `TestOWContinuizeUtils`:
+        def `test_dummy_coding_zero_based`:
+            foo: null
+            abc: null
+            foo=b: null
+            foo=c: null
+        def `test_dummy_coding_base_value`:
+            foo: null
+            abc: null
+            foo=b: null
+            foo=c: null
+            foo=a: null
+        def `test_one_hot_coding`:
+            foo: null
+            abc: null
+            foo={c}: null
+    class `TestWeightedIndicator`:
+        def `test_equality`:
+            d1: null
+            abc: null
+            d2: null
+    __main__: null
+widgets/data/tests/test_owcorrelations.py:
+    class `TestOWCorrelations`:
+        def `setUpClass`:
+            iris: null
+            zoo: null
+            heart_disease: null
+            housing: null
+        def `test_input_data_with_constant_features`:
+            c1: null
+            c2: null
+            d1: null
+        def `test_input_data_cont_target`:
+            MEDV: null
+        def `test_output_correlations`:
+            Correlation: Korelacije
+            FDR: null
+        def `test_correlation_type`:
+            Spearman correlation: Spearmanova korelacija
+        def `test_select_feature`:
+            petal length: null
+            petal width: null
+            sepal length: null
+        def `test_vizrank_use_heuristic`:
+            Orange.widgets.data.owcorrelations.SIZE_LIMIT: null
+        def `test_select_feature_against_heuristic`:
+            Orange.widgets.data.owcorrelations.SIZE_LIMIT: null
+    class `TestCorrelationRank`:
+        def `setUpClass`:
+            iris: null
+        def `test_row_for_state`:
+            +0.200: null
+    class `TestKMeansCorrelationHeuristic`:
+        def `setUpClass`:
+            datasets/breast-cancer-wisconsin: null
+        def `test_get_states_one_cluster`:
+            iris: null
+    __main__: null
+widgets/data/tests/test_owcreateclass.py:
+    class `TestHelpers`:
+        def `setUpClass`:
+            abc: null
+            a: null
+            bc: null
+            abcd: null
+            aa: null
+            bcd: null
+            rabc: null
+            x: null
+        def `test_map_by_substring`:
+            abc: null
+            a: null
+            bc: null
+            Bc: null
+        def `test_map_by_substring_with_map_values`:
+            abc: null
+            a: null
+            bc: null
+        def `test_value_from_string_substring`:
+            x: null
+            Orange.widgets.data.owcreateclass.map_by_substring: null
+        def `test_value_string_substring_flags`:
+            x: null
+            Orange.widgets.data.owcreateclass.map_by_substring: null
+        def `test_value_from_discrete_substring`:
+            x: null
+        def `test_value_from_discrete_substring_flags`:
+            x: null
+            Orange.widgets.data.owcreateclass.map_by_substring: null
+        def `test_valuefromstringsubstring_equality`:
+            d1: null
+            d2: null
+            abc: null
+            def: null
+            ghi: null
+        def `test_valuefromsdiscretesubstring_equality`:
+            d1: null
+            abc: null
+            ghi: null
+            d2: null
+            def: null
+    class `TestOWCreateClass`:
+        def `setUp`:
+            heart_disease: null
+            zoo: null
+            iris: null
+        def `_test_default_rules`:
+            C{i}: null
+        def `test_string_data`:
+            a: null
+            54: null
+            47: null
+            class: razred
+            name: null
+        def `_set_repeated`:
+            repeated: null
+            a: null
+            not repeated: null
+            b: null
+            c: null
+        def `_check_repeated`:
+            repeated: null
+            not repeated: null
+            def `new_class`:
+                a: null
+                repeated: null
+                b: null
+                not repeated: null
+                c: null
+                ?: null
+        def `_set_thal`:
+            thal: null
+            Cls1: null
+            Cls2: null
+            eversa: null
+            efect: null
+        def `_check_thal`:
+            thal: null
+            117: null
+            18: null
+            + 117: null
+            Cls1: null
+            Cls2: null
+            class: razred
+            reversable defect: null
+            fixed defect: null
+        def `test_flow_and_context_handling`:
+            C1: null
+            class: razred
+            thal: null
+            gender: null
+            ema: null
+            97: null
+            206: null
+            ma: null
+            + 97: null
+            C2: null
+            female: null
+        def `test_add_remove_lines`:
+            Cls3: null
+            a: null
+            117: null
+            18: null
+            + 117: null
+            166: null
+            c: null
+            b: null
+            Cls1: null
+            Cls2: null
+            eversa: null
+            efect: null
+        def `test_report`:
+            thal: null
+            Cls3: null
+            a: null
+            b: null
+            c: null
+        def `test_bad_class_name`:
+            def `assertError`:
+                Data: null
+            class: null
+            gender: null
+            '  class ': null
+        def `test_same_class`:
+            a: null
+    __main__: null
+widgets/data/tests/test_owcreateinstance.py:
+    class `TestOWCreateInstance`:
+        def `setUp`:
+            iris: null
+        def `test_output`:
+            created: ustvarjeni
+        def `test_output_append_data`:
+            Source ID: Vir
+            iris: null
+            created: ustvarjeni
+            __source_widget: null
+        def `_get_init_buttons`:
+            buttonBox: null
+        def `test_table`:
+            zoo: null
+        def `test_missing_values`:
+            c: null
+            m: null
+            a: null
+            b: null
+        def `test_cascade_widgets`:
+            Source ID: Vir
+        def `test_cascade_widgets_attributes`:
+            __source_widget: null
+        def `test_cascade_widgets_class_vars`:
+            __source_widget: null
+    class `TestDiscreteVariableEditor`:
+        def `setUp`:
+            Foo: null
+            Bar: null
+        def `test_init`:
+            Foo: null
+        def `test_edit`:
+            Bar: null
+        def `test_set_value`:
+            Bar: null
+        def `test_edit_missing_value`:
+            ?: null
+        def `test_set_missing_value`:
+            ?: null
+    class `TestContinuousVariableEditor`:
+        def `setUp`:
+            iris: null
+        def `test_missing_values`:
+            var: null
+        def `test_overflow`:
+            var: null
+    class `TestStringVariableEditor`:
+        def `test_edit`:
+            Foo: null
+        def `test_set_value`:
+            Foo: null
+    class `TestTimeVariableEditor`:
+        def `setUp`:
+            var: null
+        def `test_have_date_have_time`:
+            var: null
+        def `test_have_time`:
+            var: null
+        def `test_no_date_no_time`:
+            var: null
+    class `TestVariableDelegate`:
+        def `setUp`:
+            iris: null
+    __main__: null
+widgets/data/tests/test_owcsvimport.py:
+    W: null
+    class `TestOWCSVFileImport`:
+        def `setUp`:
+            _local_settings: null
+        ascii: null
+        data-regions.tab: null
+        def `_check_data_regions`:
+            id: null
+            continent: null
+            state: null
+            UK: null
+            Russia: null
+            Mexico: null
+        def `test_restore`:
+            data-regions.tab: null
+            _session_items: null
+            Data: null
+            data-regions: null
+        def `test_restore_from_local`:
+            data-regions.tab: null
+            recent: null
+            path: null
+            options: null
+            _session_items_v2: null
+            'local settings item must be recorded in _session_items_v2 when ': null
+            activated: null
+            Data: null
+        def `test_type_guessing`:
+            data-csv-types.tab: null
+            _session_items: null
+            __version__: null
+            Data: null
+            time: null
+            discrete1: null
+            discrete2: null
+            numeric1: null
+            numeric2: null
+            string: null
+        def `test_discrete_values_sort`:
+            data-csv-types.tab: null
+            ascii: null
+            _session_items: null
+            __version__: null
+            Data: null
+            1: null
+            3: null
+            4: null
+            5: null
+            12: null
+        def `test_backward_compatibility`:
+            data-csv-types.tab: null
+            _session_items: null
+            __version__: null
+            Data: null
+            time: null
+            discrete1: null
+            discrete2: null
+            numeric1: null
+            numeric2: null
+            string: null
+        def `_browse_setup`:
+            _browse_dialog: null
+            exec: null
+        def `test_browse_prefix`:
+            basedir: null
+        def `test_browse_prefix_parent`:
+            bs: null
+            basedir: null
+        def `test_browse_for_missing`:
+            /this file does not exist.csv: null
+            _session_items: null
+        def `test_browse_for_missing_prefixed`:
+            __version__: null
+            _session_items_v2: null
+            basedir: null
+            this file does not exist.csv: null
+            data-regions.tab: null
+        def `test_browse_for_missing_prefixed_parent`:
+            origin1: null
+            basedir: null
+            this file does not exist.csv: null
+            __version__: null
+            _session_items_v2: null
+    class `TestImportDialog`:
+        def `test_dialog`:
+            grep_file.txt: null
+            utf-8: null
+            ' ': null
+            \": null
+            \\: null
+    class `TestModel`:
+        def `test_model`:
+            prefix: null
+            data-regions.tab: null
+            ${prefix}/data-regions.tab (missing): ${prefix}/data-regions.tab (ne obstaja)
+            ${prefix}/data-regions.tab: null
+    class `TestUtils`:
+        def `test_load_csv`:
+            1/1/1990,1.0,[,one,\n: null
+            1/1/1990,2.0,],two,\n: null
+            1/1/1990,3.0,{,three,: null
+            ascii: null
+            M8[ns]: null
+            category: null
+            one: null
+            three: null
+        def `test_convert`:
+            I, J,  K\n: null
+            ' , A,   \n': null
+            B,  ,  1\n: null
+            ?, ., NA: null
+            ascii: null
+            B: null
+            ?: null
+            1: null
+            NA: null
+        def `test_decimal_format`:
+            class `Dialect`:
+                ;: null
+            3,21;3,37\n4,13;1.000,142: null
+            ascii: null
+            ,: null
+            .: null
+        def `test_open_compressed`:
+            abc: null
+            txt: null
+            gz: null
+            bz2: null
+            xz: null
+            zip: null
+            .{ext}: null
+            wt: null
+            ascii: null
+            rt: null
+        def `test_sniff_csv`:
+            A|B|C\n1|2|3\n1|2|3: null
+            '|': null
+            .: null
+    def `_open_write`:
+        w: null
+        wb: null
+        wt: null
+        r: null
+        .gz: null
+        .bz2: null
+        .xz: null
+        .zip: null
+        t: null
+    __main__: null
+widgets/data/tests/test_owdatainfo.py:
+    class `TestOWDataInfo`:
+        def `test_data`:
+            abc: null
+            xyz: null
+            nm: null
+            att 1: null
+            att 2: null
+            att 3: null
+            name: null
+            foo: null
+            bar: null
+        def `test_sparse`:
+            xyzuw: null
+        def `test_sql`:
+            class `SqlTable`:
+                foo: null
+                bar: null
+            y: null
+            Orange.widgets.data.owdatainfo.SqlTable: null
+            threading.Thread: null
+            _p_size: null
+    __main__: null
+widgets/data/tests/test_owdatasampler.py:
+    class `TestOWDataSampler`:
+        def `setUpClass`:
+            iris: null
+            zoo: null
+        def `test_bigger_size_with_replacement`:
+            'Should be able to set a bigger size ': null
+            with replacement: null
+        def `test_cv_output_migration`:
+            sampling_type: null
+            compatibility_mode: null
+            __version__: null
+    __main__: null
+widgets/data/tests/test_owdatasets.py:
+    class `TestOWDataSets`:
+        def `test_no_internet_connection`:
+            Orange.widgets.data.owdatasets.list_remote: null
+            Orange.widgets.data.owdatasets.list_local: null
+            Orange.widgets.data.owdatasets.log: null
+        def `test_only_local`:
+            Orange.widgets.data.owdatasets.list_remote: null
+            Orange.widgets.data.owdatasets.list_local: null
+            core: null
+            foo.tab: null
+            Orange.widgets.data.owdatasets.log: null
+        def `test_filtering`:
+            Orange.widgets.data.owdatasets.list_remote: null
+            Orange.widgets.data.owdatasets.list_local: null
+            core: null
+            foo.tab: null
+            language: null
+            English: null
+            bar.tab: null
+            Slovenščina: null
+            Orange.widgets.data.owdatasets.log: null
+            foo: null
+            baz: null
+        def `test_download_iris`:
+            Orange.widgets.data.owdatasets.list_remote: null
+            core: null
+            iris.tab: null
+            Orange.widgets.data.owdatasets.list_local: null
+            Orange.widgets.data.owdatasets.ensure_local: null
+        def `test_dir_depth`:
+            Orange.widgets.data.owdatasets.list_remote: null
+            Orange.widgets.data.owdatasets.list_local: null
+            dir1: null
+            dir2: null
+            foo.tab: null
+            bar.tab: null
+            Orange.widgets.data.owdatasets.log: null
+    __main__: null
+widgets/data/tests/test_owdiscretize.py:
+    class `DataMixin`:
+        def `prepare_data`:
+            x: null
+            y: null
+            z: null
+            t: null
+            u: null
+    class `TestOWDiscretize`:
+        def `test_empty_data`:
+            iris: null
+        def `test_report`:
+            brown-selected: null
+            var_hints: null
+            alpha 0: null
+            alpha 7: null
+            alpha 14: null
+            alpha 21: null
+            0.05: null
+            alpha 28: null
+            alpha 35: null
+            alpha 42: null
+            0, 0.125: null
+            alpha 49: null
+            __version__: null
+        def `test_all`:
+            brown-selected: null
+            var_hints: null
+            alpha 0: null
+            alpha 7: null
+            alpha 14: null
+            alpha 21: null
+            0.05: null
+            alpha 28: null
+            alpha 35: null
+            alpha 42: null
+            0, 0.125: null
+            alpha 49: null
+            __version__: null
+            < 0: null
+            ≥ 0: null
+            < -0.15: null
+            -0.15 - -0.10: null
+            -0.10 - -0.05: null
+            -0.05 - 0.00: null
+            0.00 - 0.05: null
+            0.05 - 0.10: null
+            ≥ 0.10: null
+            0 - 0.125: null
+            ≥ 0.125: null
+        def `test_get_values`:
+            6: null
+            7: null
+            1, 2, 3, 4, 5: null
+        def `test_set_values`:
+            6: null
+            7: null
+            1, 2, 3, 4, 5: null
+        def `test_varkeys_for_selection`:
+            x: null
+            u: null
+        def `test_change_selection_update_interface`:
+            x: null
+            10: null
+            y: null
+            z: null
+            5: null
+            t: null
+        def `test_update_hints`:
+            10: null
+            x: null
+            y: null
+            z: null
+            t: null
+            5: null
+            u: null
+        def `test_discretize_var`:
+            x: null
+            t: null
+            10: null
+            keep: ohrani
+            foo error: null
+            <: null
+            removed: odstranjena
+            1000: null
+            1, 2, 3: null
+        def `test_update_discretizations`:
+            ytu: null
+            x: null
+            y: null
+            z: null
+            t: null
+            u: null
+        def `test_copy_to_manual`:
+            x: null
+            2.5, 7.5, 12.5: null
+            z: null
+            4.5, 9.5, 14.5: null
+            y: null
+            3.5, 8.5, 13.5: null
+            u: null
+        def `test_migration_2_3`:
+            saved_var_states: null
+            age: null
+            rest SBP: null
+            cholesterol: null
+            max HR: null
+            ST by exercise: null
+            major vessels colored: null
+            __version__: null
+            autosend: null
+            controlAreaVisible: null
+            default_cutpoints: null
+            default_k: null
+            default_method_name: null
+            EqualFreq: null
+            context_settings: null
+            var_hints: null
+            "'1, 2, 3'": null
+    class `TestValidator`:
+        def `test_validate`:
+            1: null
+            ,: null
+            -: null
+            1,,: null
+            1,a,: null
+            a: null
+            1,1: null
+            1,12: null
+            '1, 2 ': null
+            '1, 2, ': null
+    class `TestModels`:
+        def `test_model`:
+            x: null
+            freq: pogostost
+            width: širina
+            3: null
+            y: null
+            keep: ohrani
+    class `TestDefaultDiscModel`:
+        def `test_data`:
+            314: null
+    class `TestUtils`:
+        def `test_show_tip`:
+            Ha Ha: null
+            tip-label: null
+            Ha: null
+        def `test_format_desc`:
+            10: null
+            1: null
+            year: leto
+            2: null
+            years: leti
+            day: dan
+            days: dneva
+            x: null
+            day(s): dan
+        def `test_fixed_width_disc`:
+            5.3.1: null
+            abc: null
+            -5: null
+            0: null
+            Orange.preprocess.discretize.FixedWidth: null
+            5.13: null
+            5: null
+            42: null
+        def `test_fixed_time_width_disc`:
+            5.3.1: null
+            5.3: null
+            abc: null
+            -5: null
+            0: null
+            Orange.preprocess.discretize.FixedTimeWidth: null
+            5: null
+            42: null
+        def `test_custom_discretization`:
+            4 5: null
+            2, 1, 5: null
+            1, foo, 13: null
+            Orange.preprocess.discretize.Discretizer.: null
+            create_discretized_var: null
+            1, 1.25, 1.5, 4: null
+        def `test_mdl_discretization`:
+            iris: null
+            Orange.preprocess.discretize.EntropyMDL: null
+        def `test_var_key`:
+            foo: null
+            bar: null
+    __main__: null
+widgets/data/tests/test_oweditdomain.py:
+    class `TestReport`:
+        def `test_rename`:
+            X: null
+            Y: null
+        def `test_annotate`:
+            X: null
+            a: null
+            1: null
+            b: null
+            z: null
+            2: null
+            j: null
+        def `test_unlinke`:
+            X: null
+            a: null
+            1: null
+            b: null
+            z: null
+            unlinked: odvezana
+        def `test_categories_mapping`:
+            C: null
+            a: null
+            b: null
+            c: null
+            aa: null
+            cc: null
+            ee: null
+            <s>: null
+        def `test_categorical_merge_mapping`:
+            C: null
+            a: null
+            b1: null
+            b2: null
+            b: null
+            c: null
+        def `test_reinterpret`:
+            T: null
+            → (: null
+    class `TestOWEditDomain`:
+        def `setUp`:
+            iris: null
+        def `test_widget_state`:
+            sepal length: null
+            iris: null
+            Iris-setosa: null
+            datasets/cyber-security-breaches.tab: null
+            Date_Posted_or_Updated: null
+            Business_Associate_Involved: null
+        def `test_output_data`:
+            Iris 2: null
+        def `test_input_from_owcolor`:
+            Data: null
+        def `test_list_attributes_remain_lists`:
+            a: null
+            list: null
+            [1, 2, 4]: null
+        def `test_annotation_bool`:
+            a: null
+            hidden: null
+            False: null
+        def `test_duplicate_names`:
+            iris: null
+            sepal height: null
+        def `test_unlink`:
+            x: null
+            y: null
+            z: null
+        def `test_time_variable_preservation`:
+            datasets/cyber-security-breaches.tab: null
+            Date: null
+        def `test_restore`:
+            Categorical: null
+            iris: null
+            Iris-setosa: null
+            Iris-versicolor: null
+            Iris-virginica: null
+            Rename: null
+            Z: null
+            AsString: null
+    class `TestEditors`:
+        def `test_variable_editor`:
+            S: null
+            A: null
+            1: null
+            B: null
+            b: null
+            T: null
+            a: null
+            2: null
+            action-add-label: null
+            action-delete-label: null
+        def `test_continuous_editor`:
+            X: null
+            A: null
+            1: null
+            B: null
+            b: null
+        def `test_discrete_editor`:
+            C: null
+            a: null
+            b: null
+            c: null
+            A: null
+            1: null
+            B: null
+        def `test_discrete_editor_add_remove_action`:
+            C: null
+            a: null
+            b: null
+            c: null
+            A: null
+            1: null
+            B: null
+            d: null
+            Should only mark item as removed: null
+            Did not change data: null
+        def `test_discrete_editor_merge_action`:
+            Orange.widgets.data.oweditdomain.GroupItemsDialog.exec: null
+            C: null
+            a: null
+            b: null
+            c: null
+            A: null
+            1: null
+            B: null
+            AA: null
+            BB: null
+            CC: null
+            other: ostalo
+            variable_changed should emit exactly once: null
+        def `test_discrete_editor_rename_selected_items_action`:
+            C: null
+            a: null
+            b: null
+            c: null
+            A: null
+            1: null
+            B: null
+            setVisible: null
+            BA: null
+            variable_changed should emit exactly once: null
+        def `test_discrete_editor_context_menu`:
+            C: null
+            a: null
+            b: null
+            c: null
+            A: null
+            1: null
+            B: null
+            setVisible: null
+        def `test_time_editor`:
+            T: null
+            A: null
+            1: null
+            B: null
+            b: null
+        A: null
+        a: null
+        aa: null
+        B: null
+        f: null
+        T: null
+        M8[us]: null
+        S: null
+        0: null
+        1: null
+        2: null
+        Detect automatically: Zaznaj samodejno
+        def `test_reinterpret_editor`:
+            Z: null
+        def `test_reinterpret_editor_simulate`:
+            type-combo: null
+            def `cb`:
+                Z: null
+            Z: null
+        def `test_unlink`:
+            X: null
+            A: null
+            1: null
+            B: null
+            b: null
+    class `TestModels`:
+        def `test_variable_model`:
+            A: null
+            g: null
+            B: null
+    class `TestDelegates`:
+        def `test_delegate`:
+            a: null
+            b: null
+            a \N{RIGHTWARDS ARROW} b: null
+            reinterpreted: pretolmačena
+            showText: null
+    class `TestTransforms`:
+        def `_test_common`:
+            _copy: null
+            A: null
+            1: null
+        def `test_continous`:
+            X: null
+        def `test_string`:
+            S: null
+        def `test_time`:
+            X: null
+        def `test_discrete`:
+            D: null
+            a: null
+            b: null
+        def `test_discrete_rename`:
+            D: null
+            a: null
+            b: null
+            A: null
+            B: null
+        def `test_discrete_reorder`:
+            D: null
+            2: null
+            3: null
+            1: null
+            0: null
+        def `test_discrete_add_drop`:
+            D: null
+            2: null
+            3: null
+            1: null
+            0: null
+            A: null
+        def `test_discrete_merge`:
+            D: null
+            2: null
+            3: null
+            1: null
+            0: null
+            x: null
+            y: null
+    class `TestReinterpretTransforms`:
+        def `setUpClass`:
+            A: null
+            a: null
+            b: null
+            c: null
+            B: null
+            0: null
+            1: null
+            2: null
+            C: null
+            D: null
+            S: null
+            T: null
+            0.1: null
+            2010: null
+            1.0: null
+            2020: null
+        def `test_as_string`:
+            a: null
+            2: null
+            0.25: null
+            00:03:00: null
+            b: null
+            1: null
+            1.25: null
+            00:06:00: null
+            c: null
+            0: null
+            0.2: null
+            00:12:00: null
+            0.0: null
+            00:00:00: null
+        def `test_as_discrete`:
+            A: null
+            a: null
+            b: null
+            c: null
+            B: null
+            0: null
+            1: null
+            2: null
+            C: null
+            0.0: null
+            0.2: null
+            0.25: null
+            1.25: null
+            D: null
+            1970-01-01 00:00:00: null
+            1970-01-01 00:03:00: null
+            1970-01-01 00:06:00: null
+            1970-01-01 00:12:00: null
+        def `test_as_time`:
+            _: null
+            07.02.2022: null
+            18.04.2021: null
+            07.02.2022 01:02:03: null
+            18.04.2021 01:02:03: null
+            2021-02-08 01:02:03+01:00: null
+            2021-02-07 01:02:03+01:00: null
+            010203: null
+            02-07: null
+            04-18: null
+            25.11.2021: null
+            25.11.2021 00:00:00: null
+            2021-11-25 00:00:00: null
+            000000: null
+            11-25: null
+            2022-02-07: null
+            2021-04-18: null
+            2022-02-07 01:02:03: null
+            2021-04-18 01:02:03: null
+            2021-02-08 01:02:03+0100: null
+            2021-02-07 01:02:03+0100: null
+            01:02:03: null
+            1900-02-07: null
+            1900-04-18: null
+            s{i}: null
+            d{i}: null
+        def `test_reinterpret_string`:
+            {v.name}_{i}: null
+            Detect automatically: null
+            0.1: null
+            2010: null
+            1.0: null
+            2020: null
+        def `test_compound_transform`:
+            a: null
+            Z1: null
+            Z2: null
+            b: null
+        def `test_to_time_variable`:
+            Detect automatically: null
+    class `TestUtils`:
+        def `test_mapper`:
+            a: null
+            b: null
+            O: null
+        def `test_as_float_or_nan`:
+            a: null
+            1.1: null
+            .2: null
+            NaN: null
+        def `test_column_str_repr`:
+            S: null
+            A: null
+            B: null
+            ?: null
+            C: null
+            0.1: null
+            1: null
+            D: null
+            a: null
+            b: null
+            T: null
+            00:00:00: null
+            00:00:01: null
+    class `TestLookupMappingTransform`:
+        def `setUp`:
+            S: null
+            a: null
+            b: null
+        def `test_transform`:
+            a: null
+            b: null
+            c: null
+        def `test_pickle`:
+            a: null
+            b: null
+            c: null
+        def `test_equality`:
+            v1: null
+            abc: null
+            v3: null
+            a: null
+            b: null
+            c: null
+    class `TestGroupLessFrequentItemsDialog`:
+        def `setUp`:
+            C: null
+            a: null
+            b: null
+            c: null
+            A: null
+            1: null
+            B: null
+        def `test_dialog_open`:
+            a: null
+            b: null
+        def `test_group_selected`:
+            a: null
+            b: null
+            BA: null
+        def `test_group_less_frequent_abs`:
+            a: null
+            b: null
+            BA: null
+            c: null
+        def `test_group_less_frequent_rel`:
+            a: null
+            b: null
+            BA: null
+            c: null
+        def `test_group_keep_n`:
+            a: null
+            b: null
+            BA: null
+            c: null
+        def `test_group_less_frequent_missing`:
+            def `_test_correctness`:
+                b: null
+                c: null
+    __main__: null
+widgets/data/tests/test_owfeatureconstructor.py:
+    class `FeatureConstructorTest`:
+        def `test_construct_variables_discrete`:
+            iris: null
+            Discrete Variable: null
+            "iris_one if iris == 'Iris-setosa' else iris_two ": null
+            if iris == 'Iris-versicolor' else iris_three: null
+            iris one: null
+            iris two: null
+            iris three: null
+        def `test_construct_variables_discrete_no_values`:
+            iris: null
+            Discrete Variable: null
+            str(iris)[-1]: null
+            ar: null
+        def `test_construct_variables_continuous`:
+            iris: null
+            Continuous Variable: null
+            pow(sepal_length + sepal_width, 2): null
+        def `test_construct_variables_datetime`:
+            housing: null
+            Date: null
+            '"2019-07-{:02}".format(int(MEDV/3))': null
+            2019-07-{int(row['MEDV'] / 3):02}: null
+        def `test_construct_variables_string`:
+            iris: null
+            String Variable: null
+            str(iris) + '_name': null
+            _name: null
+        def `test_construct_numeric_names`:
+            iris: null
+            0.1: null
+            1: null
+            S: null
+            _0_1 + _1: null
+        def `test_construct_placement`:
+            ab: null
+            x: null
+            a + b: null
+            y: null
+            z: null
+        def `test_unicode_normalization`:
+            \u00b5: null
+            Micro Variable: null
+        def `test_transform_sparse`:
+            A: null
+            X: null
+    class `TestTools`:
+        def `test_free_vars`:
+            foo: null
+            single: null
+            foo; bar();: null
+            exec: null
+            def `freevars_`:
+                eval: null
+            1: null
+            ...: null
+            a: null
+            f(1): null
+            f: null
+            f(x): null
+            x: null
+            a + 1: null
+            a + b: null
+            b: null
+            a[b]: null
+            f(x, *a): null
+            f(x, *a, y=1): null
+            f(x, *a, y=1, **k): null
+            k: null
+            f(*a, *b, k=c, **d, **e): null
+            c: null
+            d: null
+            e: null
+            True: null
+            "'True'": null
+            None: null
+            b'None': null
+            a < b: null
+            a < b <= c: null
+            1 < a <= 3: null
+            {}: null
+            []: null
+            (): null
+            [a, 1]: null
+            '{a: b}': null
+            {a, b}: null
+            0 if abs(a) < 0.1 else b: null
+            abs: null
+            'lambda: a': null
+            'lambda a: b + 1': null
+            'lambda a: a + 1': null
+            '(lambda a: a + 1)(a)': null
+            'lambda a, *arg: arg + (a,)': null
+            'lambda a, *arg, **kwargs: arg + (a,)': null
+            'lambda a: a + c': null
+            'lambda a, b=k: a + c': null
+            'lambda *a, b=k: a + c': null
+            'lambda a,/, b=k: a + c': null
+            'lambda a,/, b=k, **kwg: a + c and kwg': null
+            [a for a in b]: null
+            [a for a, k in b]: null
+            [(a, j) for a in b]: null
+            j: null
+            [a for k in b for a in k]: null
+            [a for k in b if k for a in k if a]: null
+            [a for k in b if kk for a in k if aa]: null
+            kk: null
+            aa: null
+            [1 + a for c in b if c]: null
+            {a for _ in [] if b}: null
+        def `test_validate_exp`:
+            1: null
+            single: null
+            a; b: null
+            exec: null
+            def `validate_`:
+                eval: null
+            a: null
+            a + 1: null
+            a < 1: null
+            1 < a: null
+            1 < a < 10: null
+            a and b: null
+            not a: null
+            a if b else c: null
+            f(x): null
+            f(g(x)) + g(x): null
+            f(x, r=b): null
+            a[b]: null
+            a in {'a', 'b'}: null
+            {}: null
+            "{'a': 1}": null
+            (): null
+            []: null
+            [i async for i in s]: null
+            (i async for i in s): null
+    class `FeatureFuncTest`:
+        def `test_reconstruct`:
+            iris: null
+            sepal width: null
+            a * sepal_width + c: null
+            sepal_width: null
+            a: null
+            c: null
+        def `test_repr`:
+            a + 1: null
+            a: null
+            FeatureFunc('a + 1', [('a', 2)], {}, None, False, None): null
+        def `test_call`:
+            iris: null
+            sepal_width + 10: null
+            sepal_width: null
+            sepal width: null
+        def `test_string_casting`:
+            zoo: null
+            name[0]: null
+            name: null
+        def `test_missing_variable`:
+            zoo: null
+            type: null
+            type[0]: null
+        def `test_time_str`:
+            T: null
+            str(T): null
+            1970-01-01: null
+        def `test_invalid_expression_variable`:
+            iris: null
+            1 / petal_length: null
+            petal_length: null
+            petal length: null
+        def `test_hash_eq`:
+            iris: null
+            1 / petal_length: null
+            petal_length: null
+            petal length: null
+    class `OWFeatureConstructorTests`:
+        def `test_create_variable_with_no_data`:
+            X1: null
+        def `test_error_invalid_expression`:
+            iris: null
+            X: null
+            0: null
+            0a: null
+        def `test_transform_error`:
+            iris: null
+            X: null
+            1/0: null
+            1: null
+        def `test_renaming_duplicate_vars`:
+            iris: null
+            0: null
+        def `test_discrete_no_values`:
+            iris: null
+            A: null
+            D1: null
+            1: null
+        def `test_missing_strings`:
+            S1: null
+            A: null
+            B: null
+            S2: null
+            S1 + S1: null
+            AA: null
+            BB: null
+        def `test_fix_values`:
+            Orange.widgets.data.owfeatureconstructor.QMessageBox: null
+            abc: null
+            ana: null
+            berta: null
+            cilka: null
+            y: null
+            ana.value + berta.value + cilka.value: null
+            ana + berta + cilka: null
+            ana.value + dani.value + cilka.value: null
+            apply: null
+            ana + dani.value + cilka: null
+            sqrt(berta): null
+            "sqrt({'a': 0, 'b': 1, 'c': 2}[berta])": null
+        def `test_migration_discrete_strings`:
+            Ana: null
+            012: null
+            Cilka: null
+            context_settings: null
+            y: null
+            Ana + int(Cilka): null
+            u: null
+            Ana.value + 'X': null
+            1X: null
+            int(Cilka): null
+        def `test_report`:
+            context_settings: null
+            a: null
+            x + 2: null
+            b: null
+            x < 3: null
+            c: null
+            x > 15: null
+            d: null
+            y > x: null
+            foo: null
+            bar: null
+            e: null
+            x ** 2 + y == 5: null
+            f: null
+            str(x): null
+            g: null
+            z: null
+            xyz: null
+            abcdefg: null
+        def `test_output_domain_picklable`:
+            iris: null
+            X1: null
+            max(0, sepal_width - 5): null
+            D1: null
+            HIGH if sepal_width > 5 else LOW: null
+            HIGH: null
+            LOW: null
+            D2: null
+            "'HIGH' if sepal_length > 5 else 'LOW'": null
+            T1: null
+            0: null
+            T2: null
+            "'1900-01-01'": null
+    class `TestFeatureEditor`:
+        def `test_has_functions`:
+            abs: null
+            sqrt: null
+    class `FeatureConstructorHandlerTests`:
+        def `test_handles_builtins_in_expression`:
+            X: null
+            str(A) + str(B): null
+            A: null
+            B: null
+            str('foo'): null
+            str(X): null
+        def `test_handles_special_characters_in_var_names`:
+            X: null
+            A_2_f: null
+            A.2 f: null
+    __main__: null
+widgets/data/tests/test_owfeaturestatistics.py:
+    VarDataPair: null
+    variable: null
+    data: null
+    continuous_full: null
+    continuous_missing: null
+    continuous_all_missing: null
+    continuous_same: null
+    rgb_full: null
+    r: null
+    g: null
+    b: null
+    rgb_missing: null
+    rgb_all_missing: null
+    rgb_bins_missing: null
+    rgb_same: null
+    ints_full: null
+    2: null
+    3: null
+    4: null
+    ints_missing: null
+    ints_all_missing: null
+    ints_bins_missing: null
+    ints_same: null
+    time_full: null
+    time_missing: null
+    time_all_missing: null
+    time_same: null
+    time_negative: null
+    string_full: null
+    a: null
+    c: null
+    d: null
+    e: null
+    string_missing: null
+    string_all_missing: null
+    string_same: null
+    class `TestVariousDataSets`:
+        def `setUp`:
+            auto_commit: null
+        def `test_runs_on_iris`:
+            iris: null
+        def `test_does_not_crash_on_empty_domain`:
+            iris: null
+        def `test_on_edge_case_datasets`:
+            Failed on `{data.name}`: null
+    class `TestFeatureStatisticsOutputs`:
+        def `setUp`:
+            auto_commit: null
+        def `test_changing_data_updates_output`:
+            iris: null
+        def `test_changing_data_updates_output_with_autocommit`:
+            iris: null
+        def `test_output_statistics`:
+            continuous_full: null
+            0: null
+            continuous_missing: null
+            rgb_full: null
+            g: null
+            rgb_missing: null
+    class `TestFeatureStatisticsUI`:
+        def `setUp`:
+            auto_commit: null
+            iris: null
+            zoo: null
+        def `test_settings_migration_to_ver21`:
+            controlAreaVisible: null
+            savedWidgetGeometry: null
+            __version__: null
+            context_settings: null
+            auto_commit: null
+            color_var: null
+            iris: null
+            selected_rows: null
+            sorting: null
+            petal length: null
+            petal width: null
+            sepal length: null
+            sepal width: null
+        def `test_report`:
+            <table>: null
+            <tr>: null
+    __main__: null
+widgets/data/tests/test_owfile.py:
+    datasets: null
+    titanic.tab: null
+    class `FailedSheetsFormat`:
+        .failed_sheet: null
+        Make a sheet function that fails: null
+        def `sheets`:
+            Not working: null
+    class `WithWarnings`:
+        .with_warning: null
+        Warning: null
+        def `read`:
+            Some warning: null
+            iris: null
+    class `MyCustomTabReader`:
+        .tab: null
+        Always return iris: null
+        def `read`:
+            iris: null
+    class `TestOWFile`:
+        def `test_describe_call_get_nans`:
+            iris: null
+            get_nan_frequency_attribute: null
+        def `test_dragEnterEvent_skips_osx_file_references`:
+            /.file/id=12345: null
+        def `test_dragEnterEvent_skips_usupported_files`:
+            file.unsupported: null
+        def `test_domain_changes_are_stored`:
+            iris: null
+            text: besedilna
+            zoo: null
+        def `test_rename_duplicates`:
+            iris: null
+            iris (1): null
+            iris (2): null
+            different iris: null
+        def `test_variable_name_change`:
+            iris: null
+            a: null
+            d: null
+            b: null
+            text: besedilna
+            c: null
+            categorical: kategorična
+            zoo: null
+            numeric: številska
+        def `test_no_last_path`:
+            recent_paths: null
+        def `test_file_not_found`:
+            test_owfile_data.tab: null
+            d1: null
+            a: null
+            b: null
+            c1: null
+            aaa: null
+            bbb: null
+            No data.: Ni podatkov.
+            iris: null
+        def `test_nothing_selected`:
+            recent_paths: null
+        def `test_check_column_noname`:
+            iris: null
+            '   ': null
+        def `test_invalid_role_mode`:
+            iris: null
+        def `test_context_match_includes_variable_values`:
+            '\
+var
+a b
+
+a
+': null
+            '\
+var
+a b c
+
+a
+': null
+            .tab: null
+            a, b: null
+            a, b, c: null
+        def `test_check_datetime_disabled`:
+            '\
+            01.08.16\t42.15\tneumann\t2017-02-20
+            03.08.16\t16.08\tneumann\t2017-02-21
+            04.08.16\t23.04\tneumann\t2017-02-22
+            03.09.16\t48.84\tturing\t2017-02-23
+            02.02.17\t23.16\tturing\t2017-02-24': null
+            .tab: null
+        def `test_reader_custom_tab`:
+            .tab: null
+            recent_paths: null
+        def `test_no_reader_extension`:
+            .xyz_unknown: null
+            recent_paths: null
+        def `test_fail_sheets`:
+            .failed_sheet: null
+        def `test_with_warnings`:
+            .with_warning: null
+        def `test_fail`:
+            name\nc\n\nstring: null
+            .tab: null
+            Orange.widgets.data.owfile.log.exception: null
+        def `test_read_format`:
+            iris: null
+            def `open_iris_with_no_spec_format`:
+                ;;: null
+            AnyQt.QtWidgets.QFileDialog.getOpenFileName: null
+            Orange.data.io.TabReader: null
+            Tab-separated: Vrednosti, ločene s tabulatorjem
+        def `test_no_specified_reader`:
+            .tab: null
+            not.a.file.reader.class: null
+            recent_paths: null
+        def `test_select_reader`:
+            iris.tab: null
+            not.a.file.reader.class: null
+            recent_paths: null
+            Tab-separated: Vrednosti, ločene s tabulatorjem
+        def `test_select_reader_errors`:
+            iris.tab: null
+            Orange.data.io.ExcelReader: null
+            recent_paths: null
+            Excel: null
+        def `test_domain_edit_no_changes`:
+            iris: null
+        def `test_domain_edit_on_sparse_data`:
+            iris: null
+            .pickle: null
+            wb: null
+        def `test_drop_data_when_everything_skipped`:
+            iris: null
+            skip: izpusti
+        def `test_call_deprecated_dialog_formats`:
+            Tab: tabulator
+        def `test_add_new_format`:
+            .tab: null
+            Orange.widgets.data.owfile.open_filename_dialog: null
+        def `test_domain_editor_conversions`:
+            'V0\tV1\tV2\tV3\tV4\tV5\tV6
+                 c\tc\td\td\tc\td\td
+                  \t \t \t \t \t \t
+                 3.0\t1.0\t4\ta\t0.0\tx\t1.0
+                 1.0\t2.0\t4\tb\t0.0\ty\t2.0
+                 2.0\t1.0\t7\ta\t0.0\ty\t2.0
+                 0.0\t2.0\t7\ta\t0.0\tz\t2.0': null
+            .tab: null
+            categorical: kategorična
+            text: besedilna
+            numeric: številska
+        def `test_domaineditor_continuous_to_string`:
+            V0\nc\n\n1.0\nnan\n3.0: null
+            .tab: null
+            text: besedilna
+            1: null
+            3: null
+        def `test_domaineditor_makes_variables`:
+            V0\tV1\nc\td\n\n1.0\t2: null
+            V0: null
+            V1: null
+            .tab: null
+            text: besedilna
+            numeric: številska
+        def `test_url_no_scheme`:
+            foo.bar/xxx.csv: null
+            Orange.widgets.data.owfile.UrlReader: null
+            http://: null
+        def `test_adds_origin`:
+            origin1/images: null
+            image: null
+            origin: null
+            origin1: null
+            origin2/images: null
+            origin2: null
+        def `test_open_moved_workflow`:
+            Orange.widgets.widget.OWWidget.workflowEnv: null
+            basedir: null
+            temp/datasets: null
+            datasets: null
+            recent_paths: null
+        def `test_files_relocated`:
+            Orange.widgets.widget.OWWidget.workflowEnv: null
+            basedir: null
+            temp/datasets: null
+            datasets: null
+            recent_paths: null
+        def `test_sheets`:
+            ..: null
+            tests: null
+            xlsx_files: null
+            header_0_sheet.xlsx: null
+            my_sheet: null
+            Sheet1: null
+            Sheet3: null
+            no such sheet: null
+        def `test_warning_from_another_thread`:
+            os.path.exists: null
+            def `read`:
+                warning from another thread: null
+            foo: null
+        def `test_warning_from_this_thread`:
+            os.path.exists: null
+            warning from this thread: null
+            foo: null
+        def `test_recent_url_serialization`:
+            load_data: null
+            https://example.com/test.tab: null
+            https://example.com/test1.tab: null
+            recent_urls: null
+    class `TestOWFileDropHandler`:
+        def `test_canDropUrl`:
+            https://example.com/test.tab: null
+            test.tab: null
+        def `test_parametersFromUrl`:
+            https://example.com/test.tab: null
+            source: null
+            recent_urls: null
+            test.tab: null
+            recent_paths: null
+            /foo.tab: null
+            foo.tab: null
+            defaults: null
+    __main__: null
+widgets/data/tests/test_owgroupby.py:
+    class `TestOWGroupBy`:
+        def `setUp`:
+            iris: null
+        def `test_data_domain_changed`:
+            Mean: Povprečje
+            Mode: Najpogostejša
+        def `test_attr_table_row_selection`:
+            Mean: Povprečje
+            Median: Mediana
+            Q1: null
+            Q3: null
+            Min. value: Najmanjša vrednost
+            Max. value: Največja vrednost
+            Mode: Najpogostejša
+            Sum: Vsota
+            Standard deviation: Standardna deviacija
+            Variance: Varianca
+            Count defined: Število znanih
+            Count: Velikost skupine
+            Concatenate: Stakni
+            Span: Razpon
+            First value: Prva vrednost
+            Last value: Zadnja vrednost
+            Random value: Naključna
+            Proportion defined: Delež znanih
+            a: null
+            b: null
+            cvar: null
+            dvar: null
+            svar: null
+        def `test_aggregations_change`:
+            Mean: Povprečje
+            Mode: Najpogostejša
+            Concatenate: Stakni
+            a: null
+            b: null
+            cvar: null
+            dvar: null
+            svar: null
+            Median: Mediana
+            Mean, Median: Povprečje, Mediana
+            Mean, Median, Mode: Povprečje, Mediana, Najpogostejša
+            Mean, Mode: Povprečje, Najpogostejša
+            Count: Velikost skupine
+            Mean, Mode, Count: Povprečje, Najpogostejša, Velikost skupine
+            Mode, Count: Najpogostejša, Velikost skupine
+            Mean, Count: Povprečje, Velikost skupine
+            Count defined: Število znanih
+            Mean, Mode, Count defined and 1 more: Povprečje, Najpogostejša, Število znanih in 1 druga
+            Mean, Mode, Count defined: Povprečje, Najpogostejša, Število znanih
+            Concatenate, Count defined: Stakni, Število znanih
+        def `test_aggregation`:
+            sval1 sval2 sval2 sval1 sval2 sval1: null
+            sval2 sval1 sval2 sval1 sval2 sval1: null
+            cvar - Mean: cvar - Povprečje
+            cvar - Median: cvar - Mediana
+            cvar - Q1: null
+            cvar - Q3: null
+            cvar - Min. value: cvar - Najmanjša vrednost
+            cvar - Max. value: cvar - Največja vrednost
+            cvar - Mode: cvar - Najpogostejša
+            cvar - Standard deviation: cvar - Standardna deviacija
+            cvar - Variance: cvar - Varianca
+            cvar - Sum: cvar - Vsota
+            cvar - Span: cvar - Razpon
+            cvar - First value: cvar - Prva vrednost
+            cvar - Last value: cvar - Zadnja vrednost
+            cvar - Count defined: cvar - Število znanih
+            cvar - Count: cvar - Velikost skupine
+            cvar - Proportion defined: cvar - Delež znanih
+            dvar - Mode: dvar - Najpogostejša
+            dvar - First value: dvar - Prva vrednost
+            dvar - Last value: dvar - Zadnja vrednost
+            dvar - Count defined: dvar - Število znanih
+            dvar - Count: dvar - Velikost skupine
+            dvar - Proportion defined: dvar - Delež znanih
+            svar - First value: svar - Prva vrednost
+            svar - Last value: svar - Zadnja vrednost
+            svar - Count defined: svar - Število znanih
+            svar - Count: svar - Velikost skupine
+            svar - Proportion defined: svar - Delež znanih
+            cvar - Concatenate: cvar - Stakni
+            dvar - Concatenate: dvar - Stakni
+            svar - Concatenate: svar - Stakni
+            a: null
+            b: null
+            val1: null
+            val2: null
+            sval1: null
+            sval2: null
+            0.1 0.2: null
+            val1 val2: null
+            sval1 sval2: null
+            0.3: null
+            0.3 0.4 0.6: null
+            val1 val2 val1: null
+            sval1 sval2 sval1: null
+            1.0 2.0: null
+            val2 val1: null
+            sval2 sval1: null
+            3.0 -4.0: null
+            5.0 5.0: null
+            Random value: Naključna
+        def `test_metas_results`:
+            svar: null
+        def `test_context`:
+            Mean: Povprečje
+            Mode: Najpogostejša
+            Concatenate: Stakni
+            Median: Mediana
+            Mean, Median: Povprečje, Mediana
+            a: null
+            b: null
+            cvar: null
+            dvar: null
+            svar: null
+        def `test_context_time_variable`:
+            T: null
+            G: null
+            G1: null
+            G2: null
+            Sum: null
+            Median: Mediana
+            Mean: Povprečje
+        def `test_unexpected_error`:
+            Orange.data.aggregate.OrangeTableGroupBy.aggregate: null
+            Test unexpected err: null
+        def `test_time_variable`:
+            ..: null
+            tests: null
+            datasets: null
+            test10.tab: null
+            c2: null
+            d2: null
+            Mean: Povprečje
+            Mode: Najpogostejša
+            Mean, Median, Q1 and 14 more: Povprečje, Mediana, Q1 in 14 drugih
+        def `test_time_variable_results`:
+            G: null
+            G1: null
+            G2: null
+            G3: null
+            T: null
+            Mode: Najpogostejša
+            Mean: Povprečje
+            Mean, Median, Q1 and 14 more: Povprečje, Mediana, Q1 in 14 drugih
+            T - Mean: T - Povprečje
+            1970-01-01 00:00:10: null
+            1970-01-01 00:12:30: null
+            1970-01-01 00:00:01: null
+            T - Median: T - Mediana
+            T - Q1: null
+            1970-01-01 00:00:05: null
+            1970-01-01 00:10:25: null
+            T - Q3: null
+            1970-01-01 00:00:15: null
+            1970-01-01 00:14:35: null
+            T - Min. value: T - Najmanjša vrednost
+            1970-01-01 00:00:00: null
+            1970-01-01 00:08:20: null
+            T - Max. value: T - Največja vrednost
+            1970-01-01 00:00:20: null
+            1970-01-01 00:16:40: null
+            T - Mode: T - Najpogostejša
+            T - Standard deviation: T - Standardna deviacija
+            T - Variance: T - Varianca
+            T - Span: T - Razpon
+            T - First value: T - Prva vrednost
+            T - Last value: T - Zadnja vrednost
+            T - Count defined: T - Število znanih
+            T - Count: T - Velikost skupine
+            T - Proportion defined: T - Delež znanih
+            T - Concatenate: T - Stakni
+            1970-01-01 00:00:00 1970-01-01 00:00:10 1970-01-01 00:00:20: null
+            1970-01-01 00:08:20 1970-01-01 00:16:40: null
+            Random value: Naključna
+            T - Random value: T - Naključna
+        def `test_tz_time_variable_results`:
+            T: null
+            G: null
+            G1: null
+            G2: null
+            1970-01-01 01:00:00+01:00: null
+            1970-01-01 01:00:10+01:00: null
+            1970-01-01 01:00:20+01:00: null
+            Mode: Najpogostejša
+            Mean: Povprečje
+            Mean, Median, Q1 and 14 more: Povprečje, Mediana, Q1 in 14 drugih
+            T - Mean: T - Povprečje
+            1970-01-01 00:00:10: null
+            T - Median: T - Mediana
+            T - Q1: null
+            1970-01-01 00:00:05: null
+            T - Q3: null
+            1970-01-01 00:00:15: null
+            T - Min. value: T - Najmanjša vrednost
+            1970-01-01 00:00:00: null
+            T - Max. value: T - Največja vrednost
+            1970-01-01 00:00:20: null
+            T - Mode: T - Najpogostejša
+            T - Standard deviation: T - Standardna deviacija
+            T - Variance: T - Varianca
+            T - Span: T - Razpon
+            T - First value: T - Prva vrednost
+            T - Last value: T - Zadnja vrednost
+            T - Count defined: T - Število znanih
+            T - Count: T - Velikost skupine
+            T - Proportion defined: T - Delež znanih
+            T - Concatenate: T - Stakni
+            1970-01-01 00:00:00 1970-01-01 00:00:10 1970-01-01 00:00:20: null
+            Random value: Naključna
+        def `test_only_nan_in_group`:
+            A: null
+            B: null
+            B - Mean: B - Povprečje
+            B - Median: B - Mediana
+            B - Q1: null
+            B - Q3: null
+            B - Min. value: B - Najmanjša vrednost
+            B - Max. value: B - Največja vrednost
+            B - Mode: B - Najpogostejša
+            B - Standard deviation: B - Standardna deviacija
+            B - Variance: B - Varianca
+            B - Sum: B - Vsota
+            B - Span: B - Razpon
+            B - First value: B - Prva vrednost
+            B - Last value: B - Zadnja vrednost
+            B - Random value: B - Naključna
+            B - Count defined: B - Število znanih
+            B - Count: B - Velikost skupine
+            B - Proportion defined: B - Delež znanih
+            B - Concatenate: B - Stakni
+            1.0 1.0: null
+    __main__: null
+widgets/data/tests/test_owimpute.py:
+    class `TestOWImpute`:
+        def `test_empty_data`:
+            iris: null
+            Data: null
+        def `test_model_error`:
+            brown-selected: null
+        def `test_select_method`:
+            iris: null
+        def `test_overall_default`:
+            c{i}: null
+            t{i}: null
+        def `test_value_edit`:
+            heart_disease: null
+            chest pain: null
+            rest SBP: null
+            cholesterol: null
+widgets/data/tests/test_owmelt.py:
+    def `data_without_commit`:
+        def `wrapped`:
+            Orange.widgets.data.owmelt.OWMelt.commit: null
+    class `TestOWMeltBase`:
+        def `setUp`:
+            gender: null
+            f: null
+            m: null
+            age: null
+            pretzels: null
+            telezka: null
+            big: null
+            small: null
+            name: null
+            greeting: null
+            ana: null
+            hi: null
+            berta: null
+            hello: null
+            cilka: null
+            evgen: null
+            foo: null
+    class `TestOWMeltFunctional`:
+        def `test_idvar_model`:
+            iris: null
+        def `test_no_suitable_features`:
+            heart_disease: null
+        def `test_invalidates`:
+            heart_disease: null
+    class `TestOWMeltUnit`:
+        def `test_is_unique`:
+            name: null
+            telezka: null
+            gender: null
+            greeting: null
+        def `test_nonnan_mask`:
+            Ana: null
+            Berta: null
+            Dani: null
+        def `test_get_useful_vars`:
+            name: null
+            gender: null
+            age: null
+            pretzels: null
+            telezka: null
+        def `test_get_item_names`:
+            age: null
+            telezka: null
+        def `test_prepare_domain_names`:
+            name: null
+            the item: null
+            the value: null
+            age: null
+            pretzels: null
+            Ana: null
+            Berta: null
+            Dani: null
+            telezka: null
+        def `test_prepare_domain_renames`:
+            age: null
+            pretzels: null
+            Ana: null
+            Berta: null
+            Dani: null
+            a: null
+            b: null
+        def `test_prepare_domain_values`:
+            name: null
+            age: null
+            pretzels: null
+            Ana: null
+            Berta: null
+            Dani: null
+            telezka: null
+        def `test_reshape_dense_by_meta`:
+            name: null
+        def `test_reshape_dense_by_attr`:
+            telezka: null
+        def `test_reshape_sparse_by_meta`:
+            name: null
+        def `test_reshape_sparse_by_attr`:
+            telezka: null
+    class `TestContextHandler`:
+        def `test_decode_calls_super`:
+            decode_setting: null
+            idvar: null
+            not_idvar: null
+        def `test_encode_calls_super`:
+            encode_setting: null
+            idvar: null
+            not_idvar: null
+    __main__: null
+widgets/data/tests/test_owmergedata.py:
+    class `TestOWMergeData`:
+        def `setUpClass`:
+            dA1: null
+            a: null
+            b: null
+            c: null
+            d: null
+            dA2: null
+            aa: null
+            bb: null
+            clsA: null
+            aaa: null
+            bbb: null
+            ccc: null
+            mA1: null
+            cc: null
+            dd: null
+            mA2: null
+            m1: null
+            m2: null
+            m3: null
+            m4: null
+            dB1: null
+            dB2: null
+            clsB: null
+            mB1: null
+            m5: null
+            dataA: null
+            dataA attributes: null
+            dataB: null
+            dataB attributes: null
+        def `test_attr_combo_tooltips`:
+            <b>: null
+        def `test_match_attr_name`:
+            dA1: null
+            a: null
+            b: null
+            c: null
+            d: null
+            dA2: null
+            aa: null
+            bb: null
+            dA3: null
+            cls: null
+            aaa: null
+            bbb: null
+            ccc: null
+            mA1: null
+            cc: null
+            dd: null
+            mA2: null
+            m1: null
+            m2: null
+            m3: null
+            m4: null
+            dB1: null
+            m5: null
+            dataA: null
+            dataA attributes: null
+            dataB: null
+            dataB attributes: null
+        def `test_migrate_settings`:
+            Position (index): null
+            attr_combine_extra: null
+            Source position (index): null
+            attr_pairs: null
+            __version__: null
+        def `test_migrate_settings_attr_pairs_extra_none`:
+            attr_pairs: null
+            sepal length: null
+            context_settings: null
+        def `test_migrate_settings_attr_pairs_data_none`:
+            attr_pairs: null
+            sepal length: null
+            context_settings: null
+        def `test_migrate_settings_attr_pairs_id_idx`:
+            attr_pairs: null
+            context_settings: null
+        def `test_migrate_settings_attr_pairs_vars`:
+            attr_pairs: null
+            sepal length: null
+            sepal width: null
+            petal length: null
+            petal width: null
+            context_settings: null
+        def `test_no_matches`:
+            dA1: null
+            dB2: null
+        def `test_output_merge_by_ids_inner`:
+            m2: null
+            m3: null
+            clsA: null
+        def `test_output_merge_by_ids_outer`:
+            clsA (1): null
+            clsA (2): null
+            m2: null
+            m3: null
+            m1: null
+            clsA: null
+        def `test_output_merge_by_ids_outer_single_class`:
+            clsA: null
+            m1: null
+            m2: null
+            m3: null
+        def `test_output_merge_by_index_left`:
+            m1: null
+            m2: null
+            m3: null
+            m4: null
+        def `test_output_merge_by_index_inner`:
+            m1: null
+            m2: null
+            m3: null
+        def `test_output_merge_by_index_outer`:
+            m1: null
+            m2: null
+            m3: null
+            m4: null
+        def `test_output_merge_by_attribute_left`:
+            m1: null
+            m2: null
+            m3: null
+            m4: null
+        def `test_output_merge_by_attribute_inner`:
+            m1: null
+            m2: null
+            m3: null
+        def `test_output_merge_by_attribute_outer`:
+            m1: null
+            m2: null
+            m3: null
+            m4: null
+        def `test_output_merge_by_attribute_outer_same_attr`:
+            name: null
+            x: null
+            y: null
+            a: null
+            b: null
+            c: null
+            d: null
+            ' ': null
+            a a b b c c  d: null
+        def `test_output_merge_by_class_left`:
+            m1: null
+            m2: null
+            m3: null
+            m4: null
+        def `test_output_merge_by_class_inner`:
+            m2: null
+            m3: null
+        def `test_output_merge_by_class_outer`:
+            m1: null
+            m2: null
+            m3: null
+            m4: null
+        def `test_output_merge_by_meta_left`:
+            m1: null
+            m2: null
+            m3: null
+            m4: null
+        def `test_output_merge_by_meta_inner`:
+            m4: null
+        def `test_output_merge_by_meta_outer`:
+            m1: null
+            m2: null
+            m3: null
+            m4: null
+        def `test_best_match`:
+            zoo: null
+            datasets/zoo-with-images.tab: null
+            name: null
+            wrong attributes chosen for merge_type={i}: null
+        def `test_sparse`:
+            iris: null
+            titanic: null
+            Data: null
+            Extra Data: null
+        def `test_multiple_attributes_left`:
+            a: null
+            b: null
+            c: null
+            d: null
+            dataA: null
+            dataB: null
+        def `test_nonunique`:
+            x: null
+            d: null
+            abc: null
+        def `test_invalide_pairs`:
+            x: null
+            d: null
+            abc: null
+        def `test_duplicate_names`:
+            C1: null
+            Feature: null
+            A: null
+            B: null
+            Feature (1): null
+            Feature (2): null
+        def `test_keep_non_duplicate_variables`:
+            A: null
+            B: null
+            B (1): null
+            B (2): null
+        def `test_keep_non_duplicate_variables_missing_rows`:
+            C: null
+            a: null
+            b: null
+            c: null
+            A: null
+            B: null
+            A (1): null
+            A (2): null
+            B (1): null
+            C (1): null
+            B (2): null
+            C (2): null
+    class `MergeDataContextHandlerTest`:
+        def `test_attr_pairs_not_present`:
+            iris: null
+            a: null
+            b: null
+            attr_pairs: null
+    __main__: null
+widgets/data/tests/test_owneighbors.py:
+    class `TestOWNeighbors`:
+        def `setUp`:
+            auto_apply: null
+            iris: null
+        def `test_input_reference_disconnect`:
+            Neighbors: null
+        def `test_output_neighbors`:
+            Neighbors: null
+        def `test_settings`:
+            Jaccard: null
+            Neighbors: null
+        def `test_similarity`:
+            Neighbors: null
+            distance: null
+        def `test_missing_values`:
+            iris: null
+            Neighbors: null
+        def `test_compute_distances_apply_called`:
+            iris: null
+        def `test_compute_distances_calls_distance`:
+            foo: null
+            iris: null
+        def `test_compute_distances_distance_no_data`:
+            foo: null
+            iris: null
+        def `test_data_with_similarity`:
+            iris: null
+            distance: null
+        def `test_apply`:
+            iris: null
+        def `test_all_equal_ref`:
+            iris: null
+        def `test_different_domains`:
+            a: null
+            b: null
+        def `test_different_metas`:
+            a: null
+            b: null
+            c: null
+            d: null
+            e: null
+        def `test_different_domains_same_names`:
+            a: null
+            b: null
+            c: null
+            d: null
+    __main__: null
+widgets/data/tests/test_owoutliers.py:
+    class `TestRun`:
+        def `test_results`:
+            iris: null
+            Outlier: null
+    class `TestOWOutliers`:
+        def `setUp`:
+            iris: null
+            heart_disease: null
+        def `test_output_empirical_covariance`:
+            Outlier: null
+            Mahalanobis: null
+        def `test_memory_error`:
+            Orange.classification.outlier_detection._OutlierModel.predict: null
+        def `test_singular_cov_error`:
+            Orange.classification.outlier_detection._OutlierModel.predict: null
+        def `test_covariance_enabled`:
+            Orange.widgets.data.owoutliers.OWOutliers.MAX_FEATURES: null
+            Orange.widgets.data.owoutliers.OWOutliers.commit: null
+        def `test_report`:
+            Orange.widgets.data.owoutliers.OWOutliers.report_items: null
+        def `test_migrate_settings`:
+            cont: null
+            empirical_covariance: null
+            gamma: null
+            nu: null
+            outlier_method: null
+            support_fraction: null
+            __version__: null
+    __main__: null
+widgets/data/tests/test_owpaintdata.py:
+    class `TestOWPaintData`:
+        def `setUp`:
+            autocommit: null
+        def `test_empty_data`:
+            iris: null
+        def `test_var_name_duplicates`:
+            iris: null
+            atr1: null
+            atr2: null
+        def `test_output_shares_internal_buffer`:
+            iris: null
+        def `test_20_values_class`:
+            A: null
+            B: null
+            C: null
+            a: null
+            t: null
+        def `test_sparse_data`:
+            iris: null
+        def `test_load_empty_data`:
+            data: null
+        def `test_reset_to_input`:
+            iris: null
+widgets/data/tests/test_owpivot.py:
+    class `TestOWPivot`:
+        def `setUp`:
+            iris: null
+            heart_disease: null
+            zoo: null
+        def `test_comboboxes`:
+            (Same as rows): (Enako kot vrstice)
+            age: null
+        def `test_output_grouped_data`:
+            iris: null
+            (count): (velikost skupine)
+            sepal length (sum): sepal length (vsota)
+            sepal width (sum): sepal width (vsota)
+            petal length (sum): petal length (vsota)
+            petal width (sum): petal width (vsota)
+        def `test_output_grouped_data_time_var`:
+            d1: null
+            a: null
+            b: null
+            t1: null
+            [[a, 2, 1987-06-06],\n [b, 2, 1976-05-03]]: null
+        def `test_output_pivot_table`:
+            iris: null
+            Aggregate: Vrednost
+            Iris-setosa: null
+            Iris-versicolor: null
+            Iris-virginica: null
+        def `test_aggregations`:
+            (None): null
+        def `test_group_table_created_once`:
+            Orange.widgets.data.owpivot.Pivot._initialize: null
+        def `test_renaming_warning`:
+            iris: null
+            Aggregate: Vrednost
+        def `test_max_values`:
+            Orange.widgets.data.owpivot.OWPivot.MAX_VALUES: null
+        def `test_table_values`:
+            gender: null
+            thal: null
+            72.0: null
+            normal: null
+            25.0: null
+            reversable defect: null
+            92.0: null
+            114.0: null
+        def `test_migrate_settings_1_to_2`:
+            sel_agg_functions: null
+    Count: Velikost skupine
+    Sum: Vsota
+    class `TestPivot`:
+        def `setUpClass`:
+            d1: null
+            a: null
+            b: null
+            d2: null
+            c: null
+            d: null
+            e: null
+            c1: null
+            c0: null
+            c2: null
+            cls: null
+            m1: null
+            m2: null
+            aa: null
+            dd: null
+            bb: null
+            ee: null
+            cc: null
+        def `test_group_table`:
+            (count): (velikost skupine)
+            d1 (count defined): d1 (število znanih)
+            d1 (majority): d1 (večina)
+            a: null
+            b: null
+            d2 (count defined): d2 (število znanih)
+            d2 (majority): d2 (večina)
+            c: null
+            d: null
+            e: null
+            c1 (count defined): c1 (število znanih)
+            c1 (sum): c1 (vsota)
+            c1 (mean): c1 (povprečje)
+            c1 (min): c1 (najmanjša)
+            c1 (max): c1 (največja)
+            c1 (mode): c1 (najpogostejša)
+            c1 (median): c1 (mediana)
+            c1 (var): c1 (varianca)
+        def `test_group_table_time_var`:
+            d1: null
+            a: null
+            b: null
+            t1: null
+            '[[a, 2, 2, a, 2, 1.1e+09, 1987-06-06, 1973-03-03, ': null
+            '2001-09-09, 1973-03-03, 1987-06-06, 2.025e+17],\n ': null
+            '[b, 2, 2, b, 1, 2e+08, 1976-05-03, 1976-05-03, ': null
+            1976-05-03, 1976-05-03, 1976-05-03, 0]]: null
+        def `test_group_table_metas`:
+            d1: null
+            a: null
+            b: null
+            c1: null
+            d2: null
+            c2: null
+            (count): (velikost skupine)
+            d1 (count defined): d1 (število znanih)
+            d1 (majority): d1 (večina)
+            c1 (count defined): c1 (število znanih)
+            c1 (sum): c1 (vsota)
+            c1 (mean): c1 (povprečje)
+            c1 (min): c1 (najmanjša)
+            c1 (max): c1 (največja)
+            c1 (mode): c1 (najpogostejša)
+            c1 (median): c1 (mediana)
+            c1 (var): c1 (varianca)
+            d2 (count defined): d2 (število znanih)
+            d2 (majority): d2 (večina)
+            c2 (count defined): c2 (število znanih)
+            c2 (sum): c2 (vsota)
+            c2 (mean): c2 (povprečje)
+            c2 (min): c2 (najmanjša)
+            c2 (max): c2 (največja)
+            c2 (mode): c2 (najpogostejša)
+            c2 (median): c2 (mediana)
+            c2 (var): c2 (varianca)
+        def `test_group_table_use_cached`:
+            Orange.widgets.data.owpivot.Pivot.Functions: null
+            Count: Velikost skupine
+            Sum: Vsota
+            Orange.widgets.data.owpivot.Pivot.Sum: null
+            Orange.widgets.data.owpivot.Pivot.Count: null
+            Orange.widgets.data.owpivot.Pivot.AutonomousFunctions: null
+            Orange.widgets.data.owpivot.Pivot.ContVarFunctions: null
+            Orange.widgets.data.owpivot.Pivot.FloatFunctions: null
+            (count): (velikost skupine)
+            d1 (count defined): d1 (število znanih)
+            d1 (majority): d1 (večina)
+            a: null
+            b: null
+            d2 (count defined): d2 (število znanih)
+            d2 (majority): d2 (večina)
+            c: null
+            d: null
+            e: null
+            c1 (count defined): c1 (število znanih)
+            c1 (sum): c1 (vsota)
+            c1 (mean): c1 (povprečje)
+            c1 (min): c1 (najmanjša)
+            c1 (max): c1 (največja)
+            c1 (mode): c1 (najpogostejša)
+            c1 (median): c1 (mediana)
+            c1 (var): c1 (varianca)
+        def `test_group_table_no_col_var`:
+            (count): (velikost skupine)
+            d1 (count defined): d1 (število znanih)
+            d1 (majority): d1 (večina)
+            a: null
+            b: null
+            d2 (count defined): d2 (število znanih)
+            d2 (majority): d2 (večina)
+            c: null
+            d: null
+            e: null
+            c1 (count defined): c1 (število znanih)
+            c1 (sum): c1 (vsota)
+            c1 (mean): c1 (povprečje)
+            c1 (min): c1 (najmanjša)
+            c1 (max): c1 (največja)
+            c1 (mode): c1 (najpogostejša)
+            c1 (median): c1 (mediana)
+            c1 (var): c1 (varianca)
+        def `test_group_table_no_col_var_metas`:
+            d1: null
+            a: null
+            b: null
+            c1: null
+            d2: null
+            c2: null
+            (count): (velikost skupine)
+            d1 (count defined): d1 (število znanih)
+            d1 (majority): d1 (večina)
+            c1 (count defined): c1 (število znanih)
+            c1 (sum): c1 (vsota)
+            c1 (mean): c1 (povprečje)
+            c1 (min): c1 (najmanjša)
+            c1 (max): c1 (največja)
+            c1 (mode): c1 (najpogostejša)
+            c1 (median): c1 (mediana)
+            c1 (var): c1 (varianca)
+            d2 (count defined): d2 (število znanih)
+            d2 (majority): d2 (večina)
+            c2 (count defined): c2 (število znanih)
+            c2 (sum): c2 (vsota)
+            c2 (mean): c2 (povprečje)
+            c2 (min): c2 (najmanjša)
+            c2 (max): c2 (največja)
+            c2 (mode): c2 (najpogostejša)
+            c2 (median): c2 (mediana)
+            c2 (var): c2 (varianca)
+        def `test_group_table_update`:
+            (count): (velikost skupine)
+            d1 (count defined): d1 (število znanih)
+            d1 (majority): d1 (večina)
+            a: null
+            b: null
+            d2 (count defined): d2 (število znanih)
+            d2 (majority): d2 (večina)
+            c: null
+            d: null
+            e: null
+            c1 (count defined): c1 (število znanih)
+            c1 (sum): c1 (vsota)
+            c1 (mean): c1 (povprečje)
+            c1 (min): c1 (najmanjša)
+            c1 (max): c1 (največja)
+            c1 (mode): c1 (najpogostejša)
+            c1 (median): c1 (mediana)
+            c1 (var): c1 (varianca)
+        def `test_group_table_1`:
+            (count): (velikost skupine)
+            c0 (count defined): c0 (število znanih)
+            c0 (sum): c0 (vsota)
+            c0 (mean): c0 (povprečje)
+            c0 (min): c0 (najmanjša)
+            c0 (max): c0 (največja)
+            c0 (mode): c0 (najpogostejša)
+            c0 (median): c0 (mediana)
+            c0 (var): c0 (varianca)
+            d1 (count defined): d1 (število znanih)
+            d1 (majority): d1 (večina)
+            a: null
+            b: null
+            c1 (count defined): c1 (število znanih)
+            c1 (sum): c1 (vsota)
+            c1 (mean): c1 (povprečje)
+            c1 (min): c1 (najmanjša)
+            c1 (max): c1 (največja)
+            c1 (mode): c1 (najpogostejša)
+            c1 (median): c1 (mediana)
+            c1 (var): c1 (varianca)
+            d2 (count defined): d2 (število znanih)
+            d2 (majority): d2 (večina)
+            c2 (count defined): c2 (število znanih)
+            c2 (sum): c2 (vsota)
+            c2 (mean): c2 (povprečje)
+            c2 (min): c2 (najmanjša)
+            c2 (max): c2 (največja)
+            c2 (mode): c2 (najpogostejša)
+            c2 (median): c2 (mediana)
+            c2 (var): c2 (varianca)
+            cls (count defined): cls (število znanih)
+            cls (majority): cls (večina)
+            m1 (count defined): m1 (število znanih)
+            m2 (count defined): m2 (število znanih)
+        def `test_pivot`:
+            Aggregate: Vrednost
+            Count: Velikost skupine
+            Count defined: Število znanih
+            Sum: Vsota
+            Mean: Povprečje
+            Min: Najmanjša
+            Max: Največja
+            Mode: Najpogostejša
+            Median: Mediana
+            Var: Varianca
+            c: null
+            d: null
+            e: null
+        def `test_pivot_total`:
+            Total: Skupno
+            Aggregate: Vrednost
+            Count: Velikost skupine
+            Sum: Vsota
+            c: null
+            d: null
+            e: null
+        def `test_pivot_no_col_var`:
+            Aggregate: Vrednost
+            Count: Velikost skupine
+            Count defined: Število znanih
+            Sum: Vsota
+            Mean: Povprečje
+            Min: Najmanjša
+            Max: Največja
+            Mode: Najpogostejša
+            Median: Mediana
+            Var: Varianca
+            a: null
+            b: null
+        def `test_pivot_no_val_var`:
+            Aggregate: Vrednost
+            Count: Velikost skupine
+            c: null
+            d: null
+            e: null
+        def `test_pivot_disc_val_var`:
+            Aggregate: Vrednost
+            Count defined: Število znanih
+            Majority: Večina
+            a: null
+            0.0: null
+            1.0: null
+            c: null
+            d: null
+            b: null
+            e: null
+        def `test_pivot_time_val_var`:
+            d1: null
+            a: null
+            b: null
+            d2: null
+            c: null
+            d: null
+            t1: null
+            Aggregate: Vrednost
+            Min: Najmanjša
+            Max: Največja
+            Count defined: Število znanih
+            Sum: Vsota
+            1.0: null
+            1973-03-03: null
+            1976-05-03: null
+            0.0: null
+            2001-09-09: null
+        def `test_pivot_data_subset`:
+            iris: null
+            Aggregate: Vrednost
+            Count: Velikost skupine
+            Count defined: Število znanih
+            Majority: Večina
+            Iris-setosa: null
+            0.0: null
+            50.0: null
+            Iris-versicolor: null
+        def `test_pivot_renaming_domain`:
+            iris: null
+            Aggregate: Vrednost
+            Aggregate (1): Vrednost (1)
+            Aggregate (2): Vrednost (2)
+    __main__: null
+widgets/data/tests/test_owpreprocess.py:
+    class `TestOWPreprocess`:
+        def `setUp`:
+            zoo: null
+        def `test_randomize`:
+            preprocessors: null
+            orange.preprocess.randomize: null
+            rand_type: null
+            rand_seed: null
+        def `test_remove_sparse`:
+            iris: null
+            preprocessors: null
+            orange.preprocess.remove_sparse: null
+            filter0: null
+            useFixedThreshold: null
+            percThresh: null
+            fixedThresh: null
+        def `test_normalize`:
+            iris: null
+            preprocessors: null
+            orange.preprocess.scale: null
+            method: null
+        def `test_select_features`:
+            iris: null
+            preprocessors: null
+            orange.preprocess.fss: null
+            strategy: null
+            k: null
+            p: null
+        def `test_data_column_nans`:
+            preprocessors: null
+            orange.preprocess.scale: null
+            center: null
+            scale: null
+    class `TestDiscretizeEditor`:
+        def `test_editor`:
+            method: null
+            n: null
+    class `TestContinuizeEditor`:
+        def `test_editor`:
+            multinomial_treatment: null
+    class `TestImputeEditor`:
+        def `test_editor`:
+            method: null
+    class `TestFeatureSelectEditor`:
+        def `test_editor`:
+            k: null
+    class `TestRandomFeatureSelectEditor`:
+        def `test_editor`:
+            strategy: null
+            k: null
+            p: null
+    class `TestRandomizeEditor`:
+        def `test_editor`:
+            rand_type: null
+    class `TestPCAEditor`:
+        def `test_editor`:
+            n_components: null
+    class `TestCUREditor`:
+        def `test_editor`:
+            rank: null
+            max_error: null
+    __main__: null
+widgets/data/tests/test_owpurgedomain.py:
+    class `TestOWPurgeDomain`:
+        def `setUp`:
+            iris: null
+    __main__: null
+widgets/data/tests/test_owpythonscript.py:
+    class `TestOWPythonScript`:
+        def `setUp`:
+            iris: null
+        def `test_inputs`:
+            Data: null
+            Learner: null
+            Classifier: null
+            Object: null
+            object: null
+        def `test_outputs`:
+            Data: null
+            Learner: null
+            Classifier: null
+            out_{0} = in_{0}: null
+            print(in_{}): null
+        def `test_local_variable`:
+            temp = 42\nprint(temp): null
+            42: null
+            print(temp): null
+            "NameError: name 'temp' is not defined": null
+        def `test_wrong_outputs`:
+            Data: null
+            Learner: null
+            Classifier: null
+            out_{} = 42: null
+            out_{0} = in_{0}: null
+        def `test_multiple_signals`:
+            titanic: null
+            in_data: null
+            in_datas: null
+            Data: null
+        def `test_store_new_script`:
+            42: null
+        def `test_restore_from_library`:
+            42: null
+        def `test_store_current_script`:
+            42: null
+        def `test_read_file_content`:
+            Content: null
+            .42: null
+            wb: null
+            \xc3\x28: null
+        def `test_script_insert_mime_text`:
+            test\n: null
+        def `test_script_insert_mime_file`:
+            test: null
+            .42: null
+            print('Hello world'): null
+            "'": null
+        def `test_dragEnterEvent_accepts_text`:
+            Content: null
+            .42: null
+        def `test_dragEnterEvent_rejects_binary`:
+            .42: null
+            wb: null
+            \xc3\x28: null
+        def `test_migrate`:
+            libraryListSource: null
+            A: null
+            1: null
+            __version__: null
+        def `test_restore`:
+            scriptLibrary: null
+            A: null
+            1: null
+            __version__: null
+        def `test_no_shared_namespaces`:
+            x = 42: null
+            y = 2 * x: null
+            "NameError: name 'x' is not defined": null
+    class `TestOWPythonScriptDropHandler`:
+        def `test_canDropFile`:
+            test.tab: null
+        def `test_parametersFromFile`:
+            scriptLibrary: null
+            filename: null
+            name: null
+            Add: null
+            script: null
+            1 + 1: null
+            42: null
+            __version__: null
+            defaults: null
+    __main__: null
+widgets/data/tests/test_owrandomize.py:
+    class `TestOWRandomize`:
+        def `setUpClass`:
+            zoo: null
+        def `test_unconditional_commit_on_new_signal`:
+            now: null
+widgets/data/tests/test_owrank.py:
+    class `SlowScorer`:
+        Slow scorer: null
+    class `TestRankModel`:
+        def `setUp`:
+            ann: null
+            ab: null
+            great: null
+            defg: null
+            def: null
+            foo: null
+            bar: null
+        def `test_data`:
+            ann: null
+            great: null
+            e: null
+            foo: null
+            bar: null
+    class `TestOWRank`:
+        def `setUp`:
+            iris: null
+            housing: null
+        def `test_input_scorer_fitter`:
+            heart_disease: null
+            random forest: null
+            sgd: null
+            ignore: null
+            .*: null
+            Scorer: null
+            Data: null
+        def `test_cls_scorer_reg_data`:
+            Orange.widgets.data.owrank.log.error: null
+        def `test_reg_scorer_cls_data`:
+            Orange.widgets.data.owrank.log.error: null
+        def `test_scores_updates_cls`:
+            Gini: null
+            Orange.widgets.data.owrank.log.error: null
+        def `test_scores_updates_reg`:
+            Univar. reg.: null
+        def `test_scores_updates_no_class`:
+            Orange.widgets.data.owrank.log.error: null
+        def `test_no_class_data_learner_class_reg`:
+            Orange.widgets.data.owrank.log.error: null
+        def `test_scores_sorting`:
+            FCBF: null
+        def `test_score_sorting_int`:
+            sorting: null
+            __version__: null
+        def `test_scores_nan_sorting`:
+            petal length: null
+        def `test_data_which_make_scorer_nan`:
+            c: null
+            d: null
+            01: null
+            ANOVA: null
+        def `test_setting_migration_fixes_header_state`:
+            headerState is not restored in Qt6: null
+            __version__: null
+            auto_apply: null
+            headerState: null
+            \x00\x00\x00\xff\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00: null
+            \x00\x00\x00\x00\x00\x01\x01\x00\x00\x00\x00\x00\x00\x00: null
+            \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\xd0\x00: null
+            \x00\x00\x08\x00\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00: null
+            \x00\x00\x00\x00\x00d\xff\xff\xff\xff\x00\x00\x00\x84\x00: null
+            \x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x14\x00\x00\x00: null
+            \x01\x00\x00\x00\x00\x00\x00\x02\xbc\x00\x00\x00\x07\x00: null
+            \x00\x00\x00: null
+            \x00\x01\x00\x00\x00\x01\x01\x00\x00\x00\x00\x00\x00\x00: null
+            \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xdc\x00: null
+            \x00\x00\x03\x00\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00: null
+            \x01\x00\x00\x00\x00\x00\x00\x00\xc8\x00\x00\x00\x02\x00: null
+            nSelected: null
+            selectMethod: null
+        def `test_auto_selection_manual`:
+            heart_disease: null
+            chest pain: null
+            rest ECG: null
+            slope peak exc ST: null
+            thal: null
+        def `test_resorting_and_selection`:
+            heart_disease: null
+        def `test_auto_send`:
+            petal width: null
+            petal length: null
+        def `test_no_attributes`:
+            iris: null
+        def `test_dataset`:
+            Orange.widgets.data.owrank.log.warning: null
+            Orange.widgets.data.owrank.log.error: null
+            ignore: null
+            Features .* are constant: null
+    __main__: null
+widgets/data/tests/test_owsave.py:
+    def `_w`:
+        /: null
+    class `MockFormat`:
+        .mock: null
+        Mock file format: null
+    class `OWSaveTestBase`:
+        def `setUp`:
+            class `OWSaveMockWriter`:
+                .csv: null
+            iris: null
+    class `TestOWSave`:
+        def `test_dataset`:
+            foo.tab: null
+        def `test_initial_start_dir`:
+            ~/: null
+            os.path.exists: null
+            /usr/foo/bar.csv: null
+            /usr/bar: null
+            /usr/bar/: null
+            /usr/bar/iris.csv: null
+            ~/iris.csv: null
+        def `test_save_file_sets_name`:
+            Orange.widgets.utils.save.owsavebase.QFileDialog.getSaveFileName: null
+            /usr/foo/bar.csv: null
+            /usr/foo/: null
+            /bar/bar.csv: null
+            /bar: null
+            bar.csv: null
+        def `test_save_file_calls_save_as`:
+            bar.csv: null
+        def `test_save_file_checks_can_save`:
+            foo: null
+        def `test_save_file_write_errors`:
+            bar/foo: null
+        def `test_save_file_write`:
+            bar/foo.csv: null
+        def `test_file_name_label`:
+            /foo/bar/baz.csv: null
+        def `test_sparse_error`:
+            foo.xlsx: null
+        def `test_send_report`:
+            foo.{writer.EXTENSIONS[0]}: null
+            for {writer}, annotations={widget.add_type_annotations}: null
+            File name: Ime datoteke
+            Type annotations: Oznake tipov
+            No: Ne
+            Yes: Da
+        def `test_migration_to_version_2`:
+            add_type_annotations: null
+            auto_save: null
+            controlAreaVisible: null
+            last_dir: null
+            /home/joe/Desktop: null
+            __version__: null
+            compress: null
+            compression: null
+            gzip (.gz): null
+            filetype: null
+            Tab-separated values (.tab): null
+            filter: null
+            Tab-separated values (*.tab): null
+            lzma (.xz): null
+            Compressed Tab-separated values (*.tab.gz): null
+            Microsoft Excel spreadsheet (.xlsx): null
+            Microsoft Excel spreadsheet (*.xlsx): null
+            Bar file (.bar): null
+        def `test_migration_to_version_3`:
+            add_type_annotations: null
+            stored_name: null
+            zoo.xlsx: null
+            __version__: null
+            zoo.tab: null
+    class `TestFunctionalOWSave`:
+        def `setUp`:
+            iris: null
+        def `test_save_uncompressed`:
+            iris: null
+            read: null
+        def `test_unsupported_file_format`:
+            Unsupported filter (*.foo): null
+            test.foo: null
+            iris: null
+            write: null
+    class `TestOWSaveLinuxDialog`:
+        linux: null
+        Tests for dialog on Linux: null
+        def `test_get_save_filename_linux`:
+            baz: null
+            abc: null
+            b: null
+            foo: null
+            bar: null
+            a;;b;;c: null
+        def `test_save_file_dialog_enforces_extension_linux`:
+            filters: null
+            Save File: null
+            foo.bar: null
+            Bar files (*.tab);;Low files (*.csv): null
+            Low files (*.csv): null
+            /foo.csv: null
+            high.bar: null
+            /high.bar.csv: null
+            Bar files (*.tab): null
+            /high.bar.tab: null
+            middle.pkl: null
+            /middle.tab: null
+            /middle.csv: null
+            high.tab.gz: null
+            /high.csv: null
+            high.tab.gz.tab.tab.gz: null
+        def `test_save_file_dialog_uses_valid_filters_linux`:
+            a (*.a): null
+            b (*.b): null
+            a (*.a);;b (*.b): null
+    class `TestOWSaveDarwinDialog`:
+        darwin: null
+        win32: null
+        Test for native dialog on Windows and macOS: null
+        def `remove_star`:
+            ' (*.': null
+            ' (.': null
+        def `test_get_save_filename_darwin`:
+            Orange.widgets.utils.save.owsavebase.QFileDialog: null
+            baz: null
+            aa (*.a): null
+            bb (*.b): null
+            cc (*.c): null
+            foo: null
+            foo.a: null
+            aa (*.a);;bb (*.b);;cc (*.c): null
+        def `test_save_file_dialog_enforces_extension_darwin`:
+            Orange.widgets.utils.save.owsavebase.QFileDialog: null
+            .tab: null
+            .csv.gz: null
+            foo: null
+            foo.tab: null
+            foo.pkl: null
+            foo.tab.gz: null
+            foo.csv.gz: null
+            foo.bar: null
+            foo.bar.tab: null
+            foo.bar.csv.gz: null
+        def `test_save_file_dialog_asks_for_overwrite_darwin`:
+            Orange.widgets.utils.save.owsavebase.QFileDialog: null
+            os.path.exists: null
+            old.tab: null
+            Orange.widgets.utils.save.owsavebase.QMessageBox: null
+            def `selected_files`:
+                old.tab: null
+                new.tab: null
+            baz: null
+            .tab: null
+            new.tab: null
+        def `test_save_file_dialog_uses_valid_filters_darwin`:
+            Orange.widgets.utils.save.owsavebase.QFileDialog: null
+            aa (*.a): null
+            bb (*.b): null
+            aa (*.a);;bb (*.b): null
+    __main__: null
+widgets/data/tests/test_owselectbydataindex.py:
+    class `TestOWSelectSubset`:
+        def `test_subset`:
+            iris: null
+        def `test_non_matching`:
+            iris: null
+        def `test_annotated`:
+            iris: null
+            No: Ne
+            Yes: Da
+        def `test_subset_nosubset`:
+            iris: null
+            titanic: null
+widgets/data/tests/test_owselectcolumns.py:
+    c: null
+    d: null
+    class `TestSelectAttributesDomainContextHandler`:
+        def `setUp`:
+            c1: null
+            d1: null
+            abc: null
+            d2: null
+            def: null
+            d3: null
+            ghi: null
+            c2: null
+            d4: null
+            jkl: null
+        def `test_open_context`:
+            d1: null
+            available: null
+            d2: null
+            meta: null
+            c1: null
+            attribute: null
+            d3: null
+            d4: null
+            c2: null
+            class: null
+        def `test_open_context_with_imperfect_match`:
+            d1: null
+            attribute: null
+            m2: null
+            meta: null
+            available: null
+            d2: null
+            c1: null
+            d6: null
+            d7: null
+            c2: null
+            class: null
+    class `TestModel`:
+        def `test_drop_mime`:
+            iris: null
+        def `test_flags`:
+            X: null
+    class `TestOWSelectAttributes`:
+        def `assertVariableCountsEqual`:
+            {name} ({nattrs}): null
+        def `test_multiple_target_variable`:
+            iris: null
+        def `test_input_features`:
+            zoo: null
+        def `test_input_features_by_name`:
+            zoo: null
+        def `test_input_features_same_domain`:
+            zoo: null
+        def `test_input_features_sub_domain`:
+            zoo: null
+        def `test_input_features_by_name_sub_domain`:
+            zoo: null
+        def `test_input_features_diff_domain`:
+            zoo: null
+            iris: null
+        def `test_input_features_no_data`:
+            zoo: null
+        def `test_input_combinations`:
+            iris: null
+        def `test_input_features_from_rank`:
+            iris: null
+        def `test_use_features_checked`:
+            iris: null
+        def `test_used_attrs_supported_types`:
+            zoo: null
+        def `_drag_enter_event`:
+            _items: null
+        def `test_move_rows`:
+            iris: null
+        def `test_drag_drop_move_rows`:
+            iris: null
+            exec: null
+        def `test_domain_new_feature`:
+            iris: null
+            a: null
+        def `test_select_new_features`:
+            iris: null
+        def `test_unselect_new_features`:
+            iris: null
+    __main__: null
+widgets/data/tests/test_owselectrows.py:
+    5.4: null
+    6.0: null
+    aardwark: null
+    cat: null
+    aa: null
+    ark: null
+    class `TestOWSelectRows`:
+        def `test_filter_cont`:
+            iris: null
+        def `test_filter_str`:
+            zoo: null
+        def `test_filter_disc`:
+            datasets/lenses.tab: null
+        def `test_filter_time`:
+            datasets/cyber-security-breaches.tab: null
+            breach_start: null
+        def `test_continuous_filter_with_c_locale`:
+            iris: null
+            is below: je manj kot
+            5.2: null
+            5,2: null
+            52: null
+        def `test_continuous_filter_with_sl_SI_locale`:
+            iris: null
+            is below: je manj kot
+            5,2: null
+            5.2: null
+            52: null
+        def `test_all_numeric_filter_with_c_locale_from_context`:
+            iris: null
+            All numeric variables: Vse številske spremenljivke
+            3.14: null
+        def `test_all_numeric_filter_with_sl_SI_locale`:
+            iris: null
+            All numeric variables: Vse številske spremenljivke
+            3,14: null
+        def `test_stores_settings_in_invariant_locale`:
+            iris: null
+            is below: je manj kot
+            5,2: null
+            conditions: null
+        def `test_store_all_numeric_filter_with_c_locale_to_context`:
+            iris: null
+            All numeric variables: Vse številske spremenljivke
+            equal: so
+            3.14: null
+            conditions: null
+        def `test_store_all_numeric_filter_with_sl_SI_locale_to_context`:
+            iris: null
+            All numeric variables: Vse številske spremenljivke
+            equal: so
+            3,14: null
+            conditions: null
+        def `test_restores_continuous_filter_in_c_locale`:
+            iris: null
+            sepal length: null
+            5.2: null
+        def `test_restores_continuous_filter_in_sl_SI_locale`:
+            iris: null
+            sepal length: null
+            5.2: null
+            5,2: null
+        def `test_partial_matches`:
+            iris: null
+            5.2: null
+        def `test_partial_match_values`:
+            iris: null
+        def `test_partial_matches_with_missing_vars`:
+            iris: null
+            5.2: null
+            4.2: null
+        def `test_load_settings`:
+            iris: null
+            is below: je manj kot
+            5.2: null
+            is at most: je največ
+            4: null
+            sepal width: null
+            sepal length: null
+        def `test_is_defined_on_continuous_variable`:
+            testing_dataset_cls: null
+            c2: null
+            is defined: je znan
+        def `test_output_filter`:
+            iris: null
+            is below: je manj kot
+            -1: null
+            10: null
+        def `test_annotated_data`:
+            iris: null
+            is: je
+            Iris-setosa: null
+        def `test_change_var_type`:
+            iris: null
+            is below: je manj kot
+            5.2: null
+        def `test_keep_operator`:
+            heart_disease: null
+            age: null
+            is not: ni
+            42: null
+            chest pain: null
+            is below: je manj kot
+            is: je
+        def `test_calendar_dates`:
+            datasets/cyber-security-breaches.tab: null
+            Date_Posted_or_Updated: null
+            is below: je manj kot
+            is greater than: je več kot
+            equals: je
+            is between: je med
+        def `test_add_all`:
+            question: null
+            iris: null
+        def `test_add_all_cancel`:
+            question: null
+            iris: null
+        def `test_report`:
+            question: null
+            zoo: null
+            All numeric variables: Vse številske spremenljivke
+            equal: so
+            42: null
+            is defined: je znan
+            is one of: je eden izmed
+        def `test_migration_to_version_1`:
+            iris: null
+            petal length: null
+        def `test_purge_discretized`:
+            housing: null
+            MEDV: null
+        def `test_meta_setting`:
+            iris: null
+        def `test_one_of_click`:
+            zoo: null
+            is one of: je eden izmed
+        def `widget_with_context`:
+            conditions: null
+        def `__set_value`:
+            Unsupported widget {}: null
+    __main__: null
+widgets/data/tests/test_owsql.py:
+    class `TestOWSqlConnected`:
+        def `setUpDB`:
+            iris: null
+        def `test_connection`:
+            postgres: null
+            Select a table: null
+            Custom SQL: null
+        def `test_output_iris`:
+            postgres: null
+            iris: null
+        def `set_connection_params`:
+            port: null
+            :: null
+            host: null
+            database: null
+            user: null
+            password: null
+    class `TestOWSql`:
+        def `test_missing_extension`:
+            Orange.widgets.data.owsql.Backend: null
+            PostgreSQL: null
+            missing extension: null
+            host: null
+            port: null
+            database: null
+            DB: null
+            schema: null
+            username: null
+            password: null
+        def `test_non_postgres`:
+            Orange.widgets.data.owsql.Backend: null
+            database: null
+            host: null
+            port: null
+            DB: null
+            schema: null
+            username: null
+            password: null
+        def `test_restore_table`:
+            Orange.widgets.data.owsql.Table: null
+            iris: null
+            Orange.widgets.data.owsql.SqlTable: null
+            Orange.widgets.data.owsql.Backend: null
+            database: null
+            a: null
+            b: null
+            c: null
+            host: null
+            port: null
+            DB: null
+            schema: null
+            username: null
+            password: null
+            table: null
+        def `test_selected_backend`:
+            Orange.data.sql.backend.base.Backend.available_backends: null
+            B1: null
+            B2: null
+            selected_backend: null
+            B3: null
+    __main__: null
+widgets/data/tests/test_owtable.py:
+    class `TestOWDataTable`:
+        def `setUpClass`:
+            Data: null
+        def `test_reset_select`:
+            heart_disease: null
+        def `test_attrs_appear_in_corner_text`:
+            c: null
+            foo: null
+            a: null
+            bar: null
+            baz: null
+            b: null
+            \na\nb\nc: null
+        def `test_unconditional_commit_on_new_signal`:
+            now: null
+        def `test_summary`:
+            No data on input: Ni vhodnih podatkov
+            No data on output: Ni izhodnih podatkov
+            zoo: null
+            {len(data)}: null
+        def `test_info`:
+            No data.: Ni podatkov.
+    class `TestOWDataTableSQL`:
+        def `test_input_data`:
+            postgres: null
+            mssql: null
+        def `test_input_data_empty`:
+            no data output: null
+        def `test_data_model`:
+            approx_len messes up row count: null
+        def `test_unconditional_commit_on_new_signal`:
+            postgres: null
+            mssql: null
+        def `test_reset_select`:
+            postgres: null
+            mssql: null
+        def `test_attrs_appear_in_corner_text`:
+            postgres: null
+            mssql: null
+        def `test_pending_selection`:
+            no data output: null
+        def `test_sorting`:
+            sorting not implemented: null
+        def `test_summary`:
+            postgres: null
+            mssql: null
+        def `test_info`:
+            does nothing: null
+        def `test_show_distributions`:
+            postgres: null
+            mssql: null
+        def `test_whole_rows`:
+            no data output: null
+        def `test_show_attribute_labels`:
+            postgres: null
+            mssql: null
+        def `test_deprecate_multiple_inputs`:
+            postgres: null
+            mssql: null
+    __main__: null
+widgets/data/tests/test_owtransform.py:
+    class `TestOWTransform`:
+        def `setUp`:
+            iris: null
+    __main__: null
+widgets/data/tests/test_owtranspose.py:
+    class `TestRunner`:
+        def `setUp`:
+            zoo: null
+        def `test_run`:
+            Feature: null
+        def `test_run_var`:
+            name: null
+            Feature: null
+        def `test_run_name`:
+            Foo: null
+        def `test_run_callback`:
+            Feature: null
+    class `TestOWTranspose`:
+        def `setUp`:
+            zoo: null
+        def `test_feature_type`:
+            datasets/test_asn_data_working.csv: null
+            Feature: Spremenljivka
+            Foo: null
+            'Foo ': null
+        def `test_remove_redundant_instance`:
+            iris: null
+            petal length: null
+        def `test_all_whitespace`:
+            '  ': null
+        def `test_error`:
+            Orange.data.Table.transpose: null
+            foo: null
+        def `test_feature_names_from_cont_vars`:
+            iris: null
+            0.2 (1): null
+            0.2 (2): null
+            0.2 (3): null
+            0.2 (4): null
+            0.2 (5): null
+            0.4 (1): null
+            0.3 (1): null
+            0.2 (6): null
+            0.2 (7): null
+            0.1 (1): null
+        def `test_unconditional_commit_on_new_signal`:
+            now: null
+    __main__: null
+widgets/data/tests/test_owunique.py:
+    class `TestOWUnique`:
+        def `setUp`:
+            a: null
+            b: null
+            c: null
+            abcd: null
+            e: null
+            fg: null
+        def `test_compute`:
+            Last instance: Zadnji primer
+            First instance: Prvi primer
+            Middle instance: Srednji primer
+            Discard non-unique instances: Zavrzi skupine z več primeri
+        def `test_use_all_when_non_selected`:
+            First instance: Prvi primer
+        def `test_no_output_on_no_unique`:
+            Discard non-unique instances: Zavrzi skupine z več primeri
+    __main__: null
+widgets/data/utils/pythoneditor/tests/test_api.py:
+    class `Selection`:
+        def `test_resetSelection`:
+            asdf fdsa: null
+        def `test_setSelection`:
+            asdf fdsa: null
+            f fd: null
+        def `test_selected_multiline_text`:
+            a\nb: null
+    class `ReplaceText`:
+        def `test_replaceText1`:
+            123456789: null
+            xyz: null
+            123xyz89: null
+        def `test_replaceText2`:
+            12345\n67890\nabcde: null
+            Z: null
+            12345\n6789Zbcde: null
+        def `test_replaceText3`:
+            12345\n67890\nabcde: null
+            Z: null
+            Z45\n67890\nabcde: null
+            12345\n67890\nabcdZ: null
+            Z12345\n67890\nabcde: null
+            12345\n67890\nabcdeZ: null
+        def `test_replaceText4`:
+            12345\n67890\nabcde: null
+            XYZ: null
+            12XYZ345\n67890\nabcde: null
+        def `test_replaceText5`:
+            12345\n67890\nabcde: null
+            Z: null
+    class `InsertText`:
+        def `test_1`:
+            123456789: null
+            xyz: null
+            123xyz456789: null
+        def `test_2`:
+            12345\n67890\nabcde: null
+            Z: null
+            12345\n6789Z0\nabcde: null
+        def `test_3`:
+            12345\n67890\nabcde: null
+            Z: null
+            Z12345\n67890\nabcde: null
+            12345\n67890\nabcdeZ: null
+    class `IsCodeOrComment`:
+        def `test_1`:
+            a + b # comment: null
+        def `test_2`:
+            '#': null
+    class `ToggleCommentTest`:
+        def `test_single_line`:
+            a = 2: null
+            '# a = 2\n': null
+            a = 2\n: null
+        def `test_two_lines`:
+            a = 2\nb = 3: null
+            '# a = 2\n# b = 3\n': null
+    class `Signals`:
+        def `test_eol_changed`:
+            \r\n: null
+    class `Lines`:
+        def `setUp`:
+            abcd\nefgh\nklmn\nopqr: null
+        def `test_accessByIndex`:
+            abcd: null
+            efgh: null
+            opqr: null
+        def `test_modifyByIndex`:
+            new text: null
+            abcd\nefgh\nnew text\nopqr: null
+        def `test_getSlice`:
+            abcd: null
+            efgh: null
+            opqr: null
+            klmn: null
+        def `test_setSlice_1`:
+            xyz: null
+            xyz\nefgh\nklmn\nopqr: null
+        def `test_setSlice_2`:
+            xyz: null
+            abcd\nxyz\nklmn\nopqr: null
+        def `test_setSlice_3`:
+            xyz: null
+            xyz\nefgh\nklmn\nopqr: null
+        def `test_setSlice_4`:
+            st: null
+            uv: null
+            wx: null
+            z: null
+            st\nuv\nwx\nz: null
+        def `test_setSlice_5`:
+            st: null
+            uv: null
+            wx: null
+            z: null
+            st\nuv\nwx\nz: null
+        def `test_setSlice_6`:
+            st: null
+            uv: null
+            abcd\nst\nuv\nopqr: null
+        def `test_setSlice_61`:
+            st: null
+            uv: null
+            wx: null
+            z: null
+        def `test_setSlice_7`:
+            st: null
+            uv: null
+            abcd\nst\nuv\nopqr: null
+        def `test_setSlice_8`:
+            st: null
+            uv: null
+            abcd\nst\nuv\nopqr: null
+        def `test_setSlice_9`:
+            st: null
+    class `LinesWin`:
+        def `setUp`:
+            \r\n: null
+    __main__: null
+widgets/data/utils/pythoneditor/tests/test_bracket_highlighter.py:
+    class `Test`:
+        def `_verify`:
+            Invalid color: null
+        def `test_1`:
+            func(param,: null
+            '     "text ( param"))': null
+    __main__: null
+widgets/data/utils/pythoneditor/tests/test_draw_whitespace.py:
+    class `Test`:
+        def `_ws_test`:
+            Failed params:\n\tany {}\n\tincorrect {}\n\ttabs {}\n\twidth {}: null
+        def `_verify`:
+            1: null
+            Item {} is not True:\n\t{}: null
+            0: null
+            Item {} is not False:\n\t{}: null
+            ' ': null
+        def `test_1`:
+            '   m xyz\t ': null
+            '   0 00011': null
+        def `test_2`:
+            \txyz\t: null
+            10001: null
+        def `test_3`:
+            '    2   3     5': null
+            111100000000000: null
+        def `test_4`:
+            ' 1 1  2   3     5\t': null
+            100011011101111101: null
+    __main__: null
+widgets/data/utils/pythoneditor/tests/test_edit.py:
+    class `Test`:
+        def `test_overwrite_edit`:
+            abcd: null
+            stu: null
+            stuabcd: null
+            xy: null
+            stuxycd: null
+            z: null
+            stuxyzcd: null
+        def `test_overwrite_backspace`:
+            abcd: null
+            a  d: null
+        def `test_overwrite_undo`:
+            abcd: null
+            axxd: null
+        def `test_home1`:
+            '  xx': null
+        def `test_home2`:
+            '\n\n    ': null
+            x: null
+    __main__: null
+widgets/data/utils/pythoneditor/tests/test_indent.py:
+    class `Test`:
+        def `test_1`:
+            ab\ncd: null
+            ab\n\tcd: null
+            ab\n    cd: null
+        def `test_2`:
+            ab\n\t\tcd: null
+            ab\n\tcd: null
+            ab\ncd: null
+        def `test_3`:
+            ab\n      cd: null
+            ab\n  cd: null
+            ab\ncd: null
+        def `test_4`:
+            '  ab\n  cd': null
+            '      ab\n      cd': null
+        def `test_4b`:
+            ab\ncd\nef: null
+            \tab\ncd\nef: null
+        def `test_5`:
+            '  ab\n  cd': null
+            '   ab\n   cd': null
+        def `test_6`:
+            '    \t  \tab': null
+            '    \t  ab': null
+            '    \tab': null
+            '    ab': null
+            ab: null
+        def `test_7`:
+            def main():: null
+            return 7: null
+    __main__: null
+widgets/data/utils/pythoneditor/tests/test_rectangular_selection.py:
+    class `_Test`:
+        def `test_real_to_visible`:
+            abcdfg: null
+            \tab\tcde\t: null
+        def `test_visible_to_real`:
+            abcdfg: null
+            \tab\tcde\t: null
+        def `test_basic`:
+            abcd\nef\nghkl\nmnop: null
+            ad\ne\ngl\nmnop: null
+        def `test_reset_by_move`:
+            abcd\nef\nghkl\nmnop: null
+            abcd\nef\ngkl\nmnop: null
+        def `test_reset_by_edit`:
+            abcd\nef\nghkl\nmnop: null
+            x: null
+        def `test_with_tabs`:
+            abcdefghhhhh\n\tklm\n\t\txyz: null
+            abcdefhh\n\tkl\n\t\tz: null
+            abcdefh\n\tkl\n\t\t: null
+            abcdefhhh\n\tkl\n\t\tyz: null
+        def `test_delete`:
+            this is long\nshort\nthis is long: null
+            'this is \nshort\nthis is ': null
+        def `test_copy_paste`:
+            xx 123 yy\n: null
+            xx 456 yy\n: null
+            xx 789 yy\n: null
+            \n: null
+            asdfghijlmn\n: null
+            x\t\n: null
+            \t\t\n: null
+            end\n: null
+            xx 123 yy\nxx 456 yy\nxx 789 yy\n\nasdfghijlm123n\nx\t      456\n\t\t  789\n\t\t\nend\n: null
+        def `test_copy_paste_utf8`:
+            фыва: null
+            фыва фыв: null
+        def `test_paste_replace_selection`:
+            asdf: null
+            asdasdf: null
+        def `test_paste_replace_rectangular_selection`:
+            asdf: null
+            asasdff: null
+        def `test_paste_new_lines`:
+            a\nb\nc\nd: null
+            x\ny: null
+            x\nya\n b\n c\n d: null
+        def `test_cut`:
+            asdf: null
+        def `test_cut_paste`:
+            abcd\nefgh\nklmn: null
+        def `test_warning`:
+            a\n: null
+            Rectangular selection area is too big: null
+    __main__: null
+widgets/data/utils/pythoneditor/tests/test_vim.py:
+    class `_Test`:
+        def `setUp`:
+            The quick brown fox: null
+            jumps over the: null
+            lazy dog: null
+            back: null
+            normal: null
+        def `click`:
+            $%^<>: null
+    class `Modes`:
+        def `test_01`:
+            normal: null
+            i123: null
+            insert: null
+            i4: null
+            1234The quick brown fox: null
+        def `test_02`:
+            A: null
+            insert: null
+            XY: null
+            lazy dogXY: null
+        def `test_03`:
+            a: null
+            insert: null
+            XY: null
+            lXYazy dog: null
+        def `test_04`:
+            normal: null
+            d: null
+            w: null
+        def `test_05`:
+            normal: null
+            R: null
+            replace: null
+            asdf: null
+            asdfquick brown fox: null
+            insert: null
+        def `test_05a`:
+            $: null
+            R: null
+            asdf: null
+            The quick brown foxasdf: null
+        def `test_06`:
+            normal: null
+            v: null
+            visual: null
+            i: null
+            insert: null
+        def `test_07`:
+            visual: null
+        def `test_08`:
+            v: null
+            kkk: null
+            V: null
+            The quick brown fox: null
+            visual lines: null
+        def `test_09`:
+            V: null
+            v: null
+            The quick brown fox: null
+            visual: null
+        def `test_10`:
+            '   indented line': null
+            j8lI: null
+            Z: null
+            '   Zindented line': null
+    class `Move`:
+        def `test_01`:
+            ll: null
+            jjj: null
+            h: null
+            k: null
+        def `test_02`:
+            word, comma, word: null
+            w: null
+        def `test_03`:
+            '  word, comma, word': null
+            e: null
+        def `test_04`:
+            $: null
+        def `test_05`:
+            0: null
+        def `test_06`:
+            G: null
+        def `test_07`:
+            gg: null
+        def `test_08`:
+            b: null
+        def `test_09`:
+            (asdf fdsa) xxx: null
+            %: null
+        def `test_10`:
+            '    indented line': null
+            ^: null
+        def `test_11`:
+            fv: null
+        def `test_12`:
+            Fv: null
+        def `test_13`:
+            tv: null
+        def `test_14`:
+            Tv: null
+        def `test_15`:
+            dff: null
+            ox: null
+        def `test_16`:
+            asdfk.xx.z  asdfk.xx.z  asdfk.xx.z asdfk.xx.z: null
+            e: null
+            E: null
+        def `test_17`:
+            asdfk.xx.z  asdfk.xx.z  asdfk.xx.z asdfk.xx.z: null
+            W: null
+        def `test_18`:
+            asdfk.xx.z  asdfk.xx.z  asdfk.xx.z asdfk.xx.z: null
+            B: null
+        def `test_19`:
+            '   indented line': null
+            '     more indented line': null
+    class `Del`:
+        def `test_01a`:
+            xxxxx: null
+            The  brown fox: null
+            k: null
+        def `test_01b`:
+            5x: null
+            The  brown fox: null
+            quick: null
+        def `test_02`:
+            dl: null
+            jmps over the: null
+            dh: null
+            mps over the: null
+        def `test_03`:
+            dj: null
+            lazy dog: null
+            back: null
+            k: null
+        def `test_04`:
+            dk: null
+            The quick brown fox: null
+            back: null
+            jumps over the: null
+            lazy dog: null
+        def `test_05`:
+            3dw: null
+            fox: null
+            'The quick brown ': null
+        def `test_06`:
+            dd: null
+            The quick brown fox: null
+            lazy dog: null
+            back: null
+        def `test_07`:
+            dG: null
+            The quick brown fox: null
+            jumps over the: null
+        def `test_08`:
+            dgg: null
+            lazy dog: null
+            back: null
+        def `test_09`:
+            llX: null
+            Te quick brown fox: null
+        def `test_10`:
+            jll: null
+            2D: null
+            The quick brown fox: null
+            ju: null
+            back: null
+    class `Edit`:
+        def `test_01`:
+            ddu: null
+        def `test_02`:
+            lllCpig: null
+            Thepig: null
+        def `test_03`:
+            j4sz: null
+            zs over the: null
+        def `test_04`:
+            rZ: null
+            The Zuick brown fox: null
+            rW: null
+            The Wuick brown fox: null
+        def `test_05`:
+            c2e: null
+            asdf: null
+            asdf brown fox: null
+        def `test_06`:
+            '    indented line': null
+            '    next indented line': null
+            o: null
+            asdf: null
+            '    asdf': null
+        def `test_07`:
+            '    indented line': null
+            '    next indented line': null
+            j: null
+            O: null
+            asdf: null
+            '    asdf': null
+        def `test_08`:
+            '    indented line': null
+            '    next indented line': null
+            ljS: null
+            xyz: null
+            '    xyz': null
+        def `test_09`:
+            (asdf fdsa) xxx: null
+            d%: null
+            ' xxx': null
+        def `test_10`:
+            2J: null
+            The quick brown fox jumps over the lazy dog: null
+            back: null
+    class `Indent`:
+        def `test_01`:
+            >2j: null
+            '    The quick brown fox': null
+            '    jumps over the': null
+            '    lazy dog': null
+            back: null
+            <j: null
+            The quick brown fox: null
+            jumps over the: null
+        def `test_02`:
+            >>: null
+            '        The quick brown fox': null
+            <<: null
+            '    The quick brown fox': null
+        def `test_03`:
+            'i    ': null
+            j: null
+            =j: null
+            '    The quick brown fox': null
+            '    jumps over the': null
+            '    lazy dog': null
+            back: null
+        def `test_04`:
+            'i    ': null
+            j: null
+            ==: null
+            '    The quick brown fox': null
+            '    jumps over the': null
+            lazy dog: null
+            back: null
+        def `test_11`:
+            v2>: null
+            '        The quick brown fox': null
+            jumps over the: null
+            v<: null
+            '    The quick brown fox': null
+        def `test_12`:
+            'i    ': null
+            j: null
+            Vj=: null
+            '    The quick brown fox': null
+            '    jumps over the': null
+            '    lazy dog': null
+            back: null
+    class `CopyPaste`:
+        def `test_02`:
+            5x: null
+            The  brown fox: null
+            p: null
+            The  quickbrown fox: null
+        def `test_03`:
+            2dd: null
+            The quick brown fox: null
+            back: null
+            kkk: null
+            p: null
+            jumps over the: null
+            lazy dog: null
+        def `test_04`:
+            2dd: null
+            The quick brown fox: null
+            back: null
+            P: null
+            jumps over the: null
+            lazy dog: null
+        def `test_05`:
+            y2y: null
+            jll: null
+            p: null
+            The quick brown fox: null
+            jumps over the: null
+            lazy dog: null
+            back: null
+        def `test_06`:
+            2wYo: null
+            P: null
+            brown fox: null
+        def `test_08`:
+            y2w: null
+            P: null
+            The quick The quick brown fox: null
+    class `Visual`:
+        def `test_01`:
+            v: null
+            visual: null
+            2w: null
+            'The quick ': null
+            x: null
+            brown fox: null
+            normal: null
+        def `test_02`:
+            vllA: null
+            'asdf ': null
+            The asdf quick brown fox: null
+        def `test_03`:
+            v8l: null
+            rz: null
+            The quick brown zzz: null
+            zzzzz over the: null
+        def `test_04`:
+            vjl: null
+            R: null
+            Z: null
+            lazy dog: null
+            back: null
+        def `test_05`:
+            vjl: null
+            u: null
+        def `test_06`:
+            ve: null
+            y: null
+            p: null
+            The quick brown quick: null
+        def `test_07`:
+            vey: null
+            ww: null
+            vep: null
+            The quick The fox: null
+        def `test_08`:
+            w: null
+            vec: null
+            slow: null
+            The slow brown fox: null
+        def `test_09`:
+            jvlX: null
+            The quick brown fox: null
+            lazy dog: null
+            back: null
+            u: null
+            jumps over the: null
+            vjD: null
+        def `test_10`:
+            vfo: null
+            The quick bro: null
+        def `test_11`:
+            jvjJ: null
+            The quick brown fox: null
+            jumps over the lazy dog: null
+            back: null
+    class `VisualLines`:
+        def `test_01`:
+            V: null
+            visual lines: null
+            x: null
+            p: null
+            jumps over the: null
+            The quick brown fox: null
+            lazy dog: null
+            back: null
+            normal: null
+        def `test_02`:
+            Vy: null
+            j: null
+            Vp: null
+            The quick brown fox: null
+            lazy dog: null
+        def `test_06`:
+            V: null
+            y: null
+            p: null
+            The quick brown fox: null
+            jumps over the: null
+        def `test_07`:
+            Vc: null
+            slow: null
+    class `Repeat`:
+        def `test_01`:
+            o: null
+            j2.: null
+            The quick brown fox: null
+            jumps over the: null
+            lazy dog: null
+            back: null
+        def `test_02`:
+            2o: null
+            j.: null
+            The quick brown fox: null
+            jumps over the: null
+            lazy dog: null
+            back: null
+        def `test_03`:
+            O: null
+            2j2.: null
+            The quick brown fox: null
+            jumps over the: null
+            lazy dog: null
+            back: null
+        def `test_04`:
+            ylp.: null
+            TTThe quick brown fox: null
+        def `test_05`:
+            x...: null
+            quick brown fox: null
+        def `test_06`:
+            Dj.: null
+            lazy dog: null
+            back: null
+        def `test_07`:
+            dw: null
+            j0.: null
+            quick brown fox: null
+            over the: null
+            lazy dog: null
+            back: null
+        def `test_08`:
+            one more: null
+            Vjx: null
+            .: null
+        def `test_09`:
+            one more: null
+            vjX: null
+            .: null
+        def `test_10`:
+            one more: null
+            Vj>: null
+            3j: null
+            .: null
+            '    The quick brown fox': null
+            '    jumps over the': null
+            lazy dog: null
+            '    back': null
+            '    one more': null
+    __main__: null
+widgets/data/utils/pythoneditor/tests/test_indenter/indenttest.py:
+    ..: null
+    tests: null
+    class `IndentTest`:
+        def `setUp`:
+            INDENT_WIDTH: null
+        def `setOrigin`:
+            \n: null
+        def `verifyExpected`:
+            \n: null
+        def `writeCursorPosition`:
+            (%d,%d): null
+        def `writeln`:
+            \n: null
+widgets/data/utils/pythoneditor/tests/test_indenter/test_python.py:
+    ..: null
+    class `Test`:
+        Python: null
+        def `test_dedentReturn`:
+            def some_function():: null
+            '  return': null
+            pass: null
+        def `test_dedentContinue`:
+            while True:: null
+            '  continue': null
+            pass: null
+        def `test_keepIndent2`:
+            class my_class():: null
+            '  def my_fun():': null
+            '    print "Foo"': null
+            '    print 3': null
+            '    pass': null
+            pass: null
+        def `test_keepIndent4`:
+            def some_function():: null
+            '  pass': null
+            pass: null
+        def `test_dedentRaise`:
+            try:: null
+            '  raise': null
+            except:: null
+        def `test_indentColon1`:
+            def some_function(param, param2):: null
+            '  pass': null
+            pass: null
+        def `test_indentColon2`:
+            def some_function(1,: null
+            '                  2):': null
+            '  pass': null
+            pass: null
+        def `test_indentColon3`:
+            '     a = {1:': null
+            '          x': null
+            x: null
+        def `test_dedentPass`:
+            def some_function():: null
+            '  pass': null
+            pass: null
+        def `test_dedentBreak`:
+            def some_function():: null
+            '  return': null
+            pass: null
+        def `test_keepIndent3`:
+            while True:: null
+            '  returnFunc()': null
+            '  myVar = 3': null
+            '  pass': null
+            pass: null
+        def `test_keepIndent1`:
+            def some_function(param, param2):: null
+            '  a = 5': null
+            '  b = 7': null
+            '  pass': null
+            pass: null
+        def `test_autoIndentAfterEmpty`:
+            while True:: null
+            '   returnFunc()': null
+            '   myVar = 3': null
+            '   x': null
+            x: null
+        def `test_hangingIndentation`:
+            '     return func (something,': null
+            '                  x': null
+            x: null
+        def `test_hangingIndentation2`:
+            '     return func (': null
+            '         something,': null
+            '         x': null
+            x: null
+        def `test_hangingIndentation3`:
+            '     a = func (': null
+            '         something)': null
+            '     x': null
+            x: null
+        def `test_hangingIndentation4`:
+            '     return func(a,': null
+            '                 another_func(1,': null
+            '                              2),': null
+            '                 x': null
+            x: null
+        def `test_hangingIndentation5`:
+            '     return func(another_func(1,': null
+            '                              2),': null
+            '                 x': null
+            x: null
+    __main__: null
+widgets/evaluate/tests/test_owcalibrationplot.py:
+    class `TestOWCalibrationPlot`:
+        def `setUp`:
+            y: null
+            a: null
+            b: null
+            datasets/lenses.tab: null
+            majority: null
+            knn-3: null
+            knn-1: null
+            ignore: null
+            .*: null
+        def `test_initialization`:
+            majority: null
+            knn-3: null
+            knn-1: null
+            '#1': null
+            '#2': null
+            a: null
+            b: null
+        def `test_regression_input_error`:
+            y: null
+        def `test_plotting_curves`:
+            Orange.widgets.evaluate.owcalibrationplot.ThresholdClassifier: null
+            Orange.widgets.evaluate.owcalibrationplot.CalibratedLearner: null
+            invalid curve for {combo.currentText()}: null
+        def `test_multiple_fold_curves`:
+            Orange.widgets.evaluate.owcalibrationplot.ThresholdClassifier: null
+            Orange.widgets.evaluate.owcalibrationplot.CalibratedLearner: null
+        def `test_change_target_class`:
+            Orange.widgets.evaluate.owcalibrationplot.ThresholdClassifier: null
+            Orange.widgets.evaluate.owcalibrationplot.CalibratedLearner: null
+        def `test_rug`:
+            def `get_rugs`:
+                connect: null
+                pairs: null
+            connect: null
+            pairs: null
+        def `test_apply_no_output`:
+            Orange.widgets.evaluate.owcalibrationplot.ThresholdClassifier: null
+            Orange.widgets.evaluate.owcalibrationplot.CalibratedLearner: null
+            abcd: null
+            each training data sample produces a different model: vsaka podmnožica učnih podatkov sestavi drug model
+            'test results do not contain stored models - try testing on ': 'rezultati vrednotenja ne vsebujejo modelov - poskusite testirati '
+            separate data or on training data: na ločenih podatkih ali na učni množici
+            select a single model - the widget can output only one: izberite posamični model
+            cannot calibrate non-binary classes: ne morem kalibrirati ne-binarnih modelov
+            def `test_shown`:
+                {msg} not included in the message: null
+        def `test_output_threshold_classifier`:
+            Orange.widgets.evaluate.owcalibrationplot.ThresholdClassifier: null
+        def `test_output_calibrated_classifier`:
+            Orange.widgets.evaluate.owcalibrationplot.CalibratedLearner: null
+        def `test_single_class`:
+            Orange.widgets.evaluate.owcalibrationplot.ThresholdClassifier: null
+            Orange.widgets.evaluate.owcalibrationplot.CalibratedLearner: null
+            def `check_error`:
+                {error} is unexpectedly: null
+                {'' if error.is_shown() else ' not'} shown: null
+        def `test_single_class_folds`:
+            Orange.widgets.evaluate.owcalibrationplot.ThresholdClassifier: null
+            Orange.widgets.evaluate.owcalibrationplot.CalibratedLearner: null
+        def `test_warn_nan_probabilities`:
+            Orange.widgets.evaluate.owcalibrationplot.ThresholdClassifier: null
+            Orange.widgets.evaluate.owcalibrationplot.CalibratedLearner: null
+        def `test_no_folds`:
+            Orange.widgets.evaluate.owcalibrationplot.ThresholdClassifier: null
+            Orange.widgets.evaluate.owcalibrationplot.CalibratedLearner: null
+    __main__: null
+widgets/evaluate/tests/test_owconfusionmatrix.py:
+    class `TestOWConfusionMatrix`:
+        def `setUpClass`:
+            titanic: null
+            Evaluation Results: null
+        def `setUp`:
+            auto_apply: null
+        def `test_show_error_on_regression`:
+            housing: null
+        def `test_unique_output_domain`:
+            iris(Learner #1): iris(Model #1)
+            iris(Learner #1) (1): iris(Model #1) (1)
+        def `test_unique_var_names`:
+            versicolor: null
+            Selected: Izbrani podatki
+            Selected (1): Izbrani podatki (1)
+            iris(Learner #1): iris(Model #1)
+            iris(Learner #1) (1): iris(Model #1) (1)
+            p(Iris-setosa): null
+            p(Iris-virginica): null
+            p(Iris-setosa) (1): null
+            p(Iris-versicolor) (1): null
+            p(Iris-virginica) (1): null
+    __main__: null
+widgets/evaluate/tests/test_owliftcurve.py:
+    1.1.1: null
+    Only test precision-recall with scikit-learn>=1.1.1: null
+    class `TestOWLiftCurve`:
+        def `setUpClass`:
+            datasets/lenses.tab: null
+        def `setUp`:
+            display_convex_hull: null
+        def `test_threshold_tooltip`:
+            heart_disease: null
+            Probability threshold(s):\n— 0.526\n— 0.4: praga verjetnosti:\n— 0.526\n— 0.4
+            Probability threshold(s):\n— 0.526\n— 0.2: praga verjetnosti:\n— 0.526\n— 0.2
+            Probability threshold(s):\n— 0.526\n— 1.0: praga verjetnosti:\n— 0.526\n— 1.0
+        def `test_point_tooltip`:
+            heart_disease: null
+            'P Rate: 0.086\nLift: 1.521\nThreshold: 1.0': Delež pozitivnih: 0.086\nDvig: 1.521\nPrag: 1.0
+        def `test_output`:
+            heart_disease: null
+        def `test_visual_settings`:
+            def `test_settings`:
+                Helvetica: null
+                tickFont: null
+                Foo: null
+                pen: null
+            Fonts: null
+            Font family: null
+            Helvetica: null
+            Title: null
+            Font size: null
+            Italic: null
+            Axis title: null
+            Axis ticks: null
+            Annotations: null
+            Foo: null
+            Figure: null
+            Line: null
+            Width: null
+            Default Line: null
+    __main__: null
+widgets/evaluate/tests/test_owpredictions.py:
+    class `TestOWPredictions`:
+        def `setUp`:
+            iris: null
+            housing: null
+        def `test_no_values_target`:
+            titanic: null
+            status: null
+            first: null
+            third: null
+            age: null
+            adult: null
+            child: null
+            sex: null
+            female: null
+            male: null
+            survived: null
+        def `test_no_class_on_test`:
+            titanic: null
+            constant: null
+        def `test_bad_data`:
+            '\
+        age\tsex\tsurvived
+        d\td\td
+        \t\tclass
+        adult\tmale\tyes
+        adult\tfemale\tno
+        child\tmale\tyes
+        child\tfemale\tyes
+        ': null
+            '\
+        age\tsex\tsurvived
+        d\td\td
+        \t\tclass
+        adult\tmale\tyes
+        adult\tfemale\tno
+        child\tmale\tyes
+        child\tfemale\tunknown
+        ': null
+        def `test_continuous_class`:
+            housing: null
+        def `test_changed_class_var`:
+            heart_disease: null
+            housing: null
+        def `test_predictor_fails`:
+            titanic: null
+            foo: null
+        def `test_sort_matching`:
+            titanic: null
+        def `test_colors_continuous`:
+            housing: null
+        def `test_unique_output_domain`:
+            constant: null
+            constant (1): null
+        def `test_selection_in_setting`:
+            selection: null
+        def `test_multi_inputs`:
+            P1: null
+            P2: null
+            P3: null
+        def `_mock_predictors`:
+            def `pred`:
+                c: null
+            def `predc`:
+                c: null
+            abc: null
+            ab: null
+            cbd: null
+            e: null
+        def `test_update_prediction_delegate_discrete`:
+            c: null
+            abc: null
+            abcde: null
+            p(a, b, c): null
+            p(a, b): null
+            p(c, b, d): null
+            p(e): null
+            p(b, c): null
+            p(a): null
+            p(b): null
+            p(c): null
+        def `test_update_delegates_continuous`:
+            c: null
+            abcde: null
+        def `test_delegate_ranges`:
+            class `Model1`:
+                foo: null
+            class `Model2`:
+                bar: null
+            x: null
+            y: null
+            abcdefghijklmnopq: null
+        def `test_change_target`:
+            Orange.widgets.evaluate.owpredictions.usable_scorers: null
+        def `test_multi_target_input`:
+            var1: null
+            c1: null
+            c2: null
+            no: null
+            yes: null
+            Mockery: null
+        def `test_regression_error_delegate_ranges`:
+            x: null
+            y: null
+        def `test_migrate_shown_scores`:
+            score_table: null
+            shown_scores: null
+            Sensitivity: null
+            show_score_hints: null
+    class `SelectionModelTest`:
+        def `setUp`:
+            iris: null
+    class `PredictionsModelTest`:
+        def `test_model_header`:
+            4: null
+            a: null
+            b: null
+            error: null
+            5: null
+    class `TestPredictionsItemDelegate`:
+        def `test_displayText`:
+            {value:.3f}: null
+            0.123: null
+            {value:.1f}: null
+            0.1: null
+            {value:.1f} - {dist[2]}: null
+            0.1 - 3: null
+    class `TestClassificationItemDelegate`:
+        def `test_format`:
+            showText: null
+            foo: null
+            bar: null
+            baz: null
+            p(foo, baz): null
+            '0.60 : - : 0.40 → baz': null
+        def `test_drawbar`:
+            foo: null
+            bar: null
+            baz: null
+            bax: null
+    class `TestRegressionItemDelegate`:
+        def `test_format`:
+            %6.3f: null
+            ' 5.130': null
+            5.10: null
+        def `test_drawBar`:
+            %6.3f: null
+    class `TestClassificationErrorDelegate`:
+        def `test_displayText`:
+            0.123: null
+            ?: null
+    class `TestRegressionErrorDelegate`:
+        def `test_displayText`:
+            %.5f: null
+            0.12346: null
+            ?: null
+            ∞: null
+            -∞: null
+        def `test_drawBar`:
+            %.5f: null
+    __main__: null
+widgets/evaluate/tests/test_owrocanalysis.py:
+    class `TestROC`:
+        def `test_ROCData_from_results`:
+            iris: null
+    class `TestOWROCAnalysis`:
+        def `setUpClass`:
+            datasets/lenses.tab: null
+            mouseRateLimit: null
+        def `setUp`:
+            display_perf_line: null
+            display_def_threshold: null
+            display_convex_hull: null
+            display_convex_curve: null
+        def `test_tooltips`:
+            n: null
+            ppnpppnnpnpnpnnnpnpn: null
+            y: null
+            pn: null
+            showText: null
+            (#1) 0.900: null
+            '#2': null
+            (#1) 1.000\n(#2) 1.000: null
+            (#1) 0.600\n(#2) 0.590: null
+        def `test_target_prior`:
+            none: null
+            soft: null
+    __main__: null
+widgets/evaluate/tests/test_owtestandscore.py:
+    class `TestOWTestAndScore`:
+        def `setUp`:
+            a: null
+            b: null
+            c: null
+            y: null
+            n: null
+        def `test_basic`:
+            iris: null
+            housing: null
+        def `test_multiple_learners`:
+            iris: null
+            M1: null
+            M2: null
+        def `test_testOnTest`:
+            iris: null
+        def `test_testOnTest_incompatible_domain`:
+            iris: null
+            x: null
+        def `test_CrossValidationByFeature`:
+            iris: null
+        def `test_migrate_removes_invalid_contexts`:
+            context_settings: null
+        def `test_migrate_shown_scores`:
+            score_table: null
+            shown_scores: null
+            Sensitivity: Občutljivost
+            show_score_hints: null
+        def `test_memory_error`:
+            iris: null
+            Orange.evaluation.testing.Results.get_augmented_data: null
+        def `test_one_class_value`:
+            a: null
+            b: null
+            c: null
+            y: null
+            yyyy: null
+            Data: null
+            Learner: null
+        def `test_data_errors`:
+            def `assertErrorShown`:
+                Data: null
+            iris: null
+            Target variable has no values.: Cijna spremenljivka nima vrednosti.
+            Target variable has only one value.: Ciljna spremenljivka ima samo eno vrednost.
+            Data has no features to learn from.: Podatki nimajo spremenljivk za učenje.
+            Train dataset is empty.: Tabela učnih primerov je prazna.
+        def `test_addon_scorers`:
+            class `NewScore`:
+                new scorer: null
+            class `NewClassificationScore`:
+                new classification scorer: null
+            iris: null
+            new scorer: null
+            new classification scorer: null
+            NewRegressionScore: null
+            housing: null
+            NewScore: null
+            NewClassificationScore: null
+        def `test_target_changing`:
+            iris: null
+            Iris-setosa: null
+            Iris-versicolor: null
+            Iris-virginica: null
+        def `test_resort_on_data_change`:
+            iris: null
+            versicolor: null
+            setosa: null
+        def `test_scores_constant`:
+            yyyn: null
+        def `test_scores_log_reg_overfitted`:
+            yyyn: null
+        def `test_scores_log_reg_bad`:
+            nnny: null
+            yyyn: null
+        def `test_scores_log_reg_bad2`:
+            nnyy: null
+            yynn: null
+        def `test_scores_log_reg_advanced`:
+            yyynn: null
+            yynnn: null
+        def `test_scores_cross_validation`:
+            iris: null
+        def `test_no_stratification`:
+            zoo: null
+            iris: null
+            housing: null
+        def `test_too_many_folds`:
+            zoo: null
+        def `_set_three_majorities`:
+            iris: null
+            maja: null
+            majb: null
+            majc: null
+        def `test_comparison_requires_cv`:
+            baycomp.two_on_single: null
+            iris: null
+        def `test_comparison_requires_multiple_models`:
+            majd: null
+        def `test_comparison_bad_slots`:
+            Classification accuracy: Klasifikacijska točnost
+        def `test_comparison_bad_scores`:
+            Classification accuracy: Klasifikacijska točnost
+            compute_score: null
+        def `test_comparison_binary_score`:
+            F1: null
+            iris: null
+            compute_score: null
+            target: null
+            average: null
+            weighted: null
+        def `test_fill_table`:
+            baycomp.two_on_single: null
+            {(row + 1) / (row + col + 2):.3f}: null
+            {probs(row, col, w.rope)[0]:.3f}: null
+            {probs(row, col, w.rope)[1]:.3f}: null
+        def `test_nan_on_comparison`:
+            baycomp.two_on_single: null
+            NA: null
+        def `test_unique_output_domain`:
+            random forest: null
+            random forest (1): null
+        def `test_copy_to_clipboard`:
+            iris: null
+            \t: null
+        def `test_multi_target_input`:
+            var1: null
+            c1: null
+            c2: null
+            no: null
+            yes: null
+            Mockery: null
+    class `TestHelpers`:
+        def `test_results_one_vs_rest`:
+            datasets/lenses.tab: null
+    __main__: null
+widgets/evaluate/tests/test_utils.py:
+    class `TestUsableScorers`:
+        def `setUp`:
+            iris: null
+            housing: null
+    class `TestScoreTable`:
+        def `setUp`:
+            class `NewScore`:
+                new score: null
+        def `tearDown`:
+            NewScore: null
+        def `test_show_column_chooser`:
+            def `execmenu`:
+                F1: F1
+                Classification accuracy (CA): Klasifikacijska točnost (Točnost)
+                Area under ROC curve (AUC): Površina pod krivuljo ROC (AUC)
+                Specificity (Spec): Specifičnost (Spec)
+                new score: null
+                error in section {scorer.name}: null
+                CA: null
+                error at {k}: null
+                AUC: null
+            AnyQt.QtWidgets.QMenu.addAction: null
+            AnyQt.QtWidgets.QMenu.exec: null
+        def `test_sorting`:
+            D: null
+            C: null
+            b: null
+            A: null
+            E: null
+            AbCDE: null
+            EDCbA: null
+            CDb: null
+            bDC: null
+            CED: null
+            DEC: null
+        def `test_shown_scores_backward_compatibility`:
+            F1: null
+            AUC: null
+            new score: null
+        def `test_migration`:
+            Sensitivity: null
+            show_score_hints: null
+    __main__: null
+widgets/model/tests/test_owadaboost.py:
+    class `TestOWAdaBoost`:
+        def `setUp`:
+            auto_apply: null
+            algorithm: null
+            classification: null
+            loss: null
+            regression: null
+            learning_rate: null
+            n_estimators: null
+            random_seed: null
+            random_state: null
+        def `test_input_learner`:
+            The default base estimator should not be none: null
+            The default base estimator should support weights: null
+            The base estimator was not updated when valid learner on input: null
+            The base estimator was not reset to default when None on input: null
+        def `test_error_message_cleared_when_valid_learner_on_input`:
+            Error message was not hidden on input disconnect: null
+            'Error message was not hidden when a valid learner appeared on ': null
+            input: null
+widgets/model/tests/test_owcalibratedlearner.py:
+    class `TestOWCalibratedLearner`:
+        def `setUp`:
+            auto_apply: null
+            heart_disease: null
+            testing_dataset_reg: null
+            Calibrated classifier: null
+        def `test_output_learner`:
+            Learner: null
+            Does not initialize the learner output: null
+            Does not send a new learner instance on `Apply`.: null
+        def `test_output_model`:
+            Data: null
+        def `test_name_changes`:
+            foo: null
+            Foo + Isotonic + CA: Foo + Izotonična + točnost
+            Foo + CA: Foo + točnost
+            Calibrated Learner: Kalibriran model
+widgets/model/tests/test_owconstant.py:
+    class `TestOWConstant`:
+        def `setUp`:
+            auto_apply: null
+widgets/model/tests/test_owcurvefit.py:
+    class `TestFunctions`:
+        def `test_functions`:
+            any: null
+            all: null
+            arctan2: null
+            copysign: null
+            fmod: null
+            gcd: null
+            hypot: null
+            isclose: null
+            ldexp: null
+            power: null
+            remainder: null
+    class `TestParameter`:
+        def `test_to_tuple`:
+            foo: null
+        def `test_repr`:
+            foo: null
+            'Parameter(name=foo, initial=2, use_lower=True, ': null
+            lower=10, use_upper=False, upper=50): null
+    class `TestParametersWidget`:
+        def `test_add_row`:
+            p1: null
+        def `test_add_row_with_data`:
+            a: null
+        def `test_set_data`:
+            a: null
+            b: null
+        def `test_reset_data`:
+            a: null
+        def `test_clear_all`:
+            a: null
+    class `TestOWCurveFit`:
+        def `setUp`:
+            auto_apply: null
+            housing: null
+        def `__init_widget`:
+            'p1 + ': null
+        def `test_output_model_name`:
+            Model Name: null
+        def `test_output_coefficients`:
+            coef: null
+            name: null
+        def `test_output_mixed_features`:
+            coef: null
+            name: null
+        def `test_features_combo`:
+            Select Feature: Izberite spremenljivko
+            CRIM: null
+        def `test_parameters_combo`:
+            Select Parameter: Izberite parameter
+            p1: null
+        def `test_function_combo`:
+            Select Function: Izberite funkcijo
+            abs(): null
+        def `test_expression`:
+            ' + ': null
+            gcd: null
+            2: null
+            arctan2: null
+            copysign: null
+            fmod: null
+            hypot: null
+            isclose: null
+            ldexp: null
+            power: null
+            remainder: null
+        def `test_sanitized_expression`:
+            heart_disease: null
+            p1 + rest_SBP: null
+        def `test_discrete_expression`:
+            heart_disease: null
+            p1 + gender_female: null
+        def `test_invalid_expression`:
+            ' + ': null
+            ' 2 ': null
+        def `test_duplicated_parameter_name`:
+            p1: null
+            p2: null
+        def `test_parameter_name_in_features`:
+            p1: null
+            cls: null
+            a: null
+        def `test_no_parameter`:
+            LSTAT + 1: null
+            LSTAT + a: null
+        def `test_unused_parameter`:
+            p1 + LSTAT + p2: null
+            p1 + LSTAT: null
+        def `test_unknown_parameter`:
+            p1 + LSTAT: null
+            p2 + LSTAT: null
+        def `test_saved_parameters`:
+            a: null
+            parameters: null
+        def `test_output`:
+            p1 * exp(-p2 * LSTAT) + p3: null
+            coef: null
+            name: null
+    __main__: null
+widgets/model/tests/test_owgradientboosting.py:
+    def `create_parent`:
+        class `DummyWidget`:
+            Mock: null
+    class `TestLearnerItemModel`:
+        def `test_missing_lib`:
+            Orange.widgets.model.owgradientboosting.LearnerItemModel.LEARNERS: null
+            Gradient Boosting (catboost): null
+            catboost: null
+    class `TestGBLearnerEditor`:
+        def `test_arguments`:
+            n_estimators: null
+            learning_rate: null
+            max_depth: null
+            random_state: null
+            subsample: null
+            min_samples_split: null
+        def `test_learner_parameters`:
+            Method: null
+            Gradient Boosting (scikit-learn): null
+            Number of trees: null
+            Learning rate: null
+            Replicable training: null
+            Yes: null
+            Maximum tree depth: null
+            Fraction of training instances: null
+            Stop splitting nodes with maximum instances: null
+        def `test_default_parameters_cls`:
+            heart_disease: null
+            n_estimators: null
+            learning_rate: null
+            max_depth: null
+            subsample: null
+            min_samples_split: null
+            random_state: null
+        def `test_default_parameters_reg`:
+            housing: null
+            n_estimators: null
+            learning_rate: null
+            max_depth: null
+            subsample: null
+            min_samples_split: null
+            random_state: null
+    class `TestXGBLearnerEditor`:
+        def `test_arguments`:
+            n_estimators: null
+            learning_rate: null
+            max_depth: null
+            reg_lambda: null
+            colsample_bytree: null
+            colsample_bylevel: null
+            colsample_bynode: null
+            subsample: null
+            random_state: null
+        def `test_learner_parameters`:
+            Missing 'xgboost' package: null
+            Method: null
+            Extreme Gradient Boosting (xgboost): null
+            Number of trees: null
+            Learning rate: null
+            Replicable training: null
+            Yes: null
+            Maximum tree depth: null
+            Regularization strength: null
+            Fraction of training instances: null
+            Fraction of features for each tree: null
+            Fraction of features for each level: null
+            Fraction of features for each split: null
+        def `test_default_parameters_cls`:
+            Missing 'xgboost' package: null
+            heart_disease: null
+            learner: null
+            gradient_booster: null
+            updater: null
+            grow_colmaker: null
+            train_param: null
+            n_estimators: null
+            learning_rate: null
+            max_depth: null
+            reg_lambda: null
+            subsample: null
+            colsample_bytree: null
+            colsample_bylevel: null
+            colsample_bynode: null
+        def `test_default_parameters_reg`:
+            Missing 'xgboost' package: null
+            housing: null
+            learner: null
+            gradient_booster: null
+            updater: null
+            grow_colmaker: null
+            train_param: null
+            n_estimators: null
+            learning_rate: null
+            max_depth: null
+            reg_lambda: null
+            subsample: null
+            colsample_bytree: null
+            colsample_bylevel: null
+            colsample_bynode: null
+    class `TestXGBRFLearnerEditor`:
+        def `test_arguments`:
+            n_estimators: null
+            learning_rate: null
+            max_depth: null
+            reg_lambda: null
+            colsample_bytree: null
+            colsample_bylevel: null
+            colsample_bynode: null
+            subsample: null
+            random_state: null
+        def `test_learner_parameters`:
+            Missing 'xgboost' package: null
+            Method: null
+            Extreme Gradient Boosting Random Forest (xgboost): null
+            Number of trees: null
+            Learning rate: null
+            Replicable training: null
+            Yes: null
+            Maximum tree depth: null
+            Regularization strength: null
+            Fraction of training instances: null
+            Fraction of features for each tree: null
+            Fraction of features for each level: null
+            Fraction of features for each split: null
+        def `test_default_parameters_cls`:
+            Missing 'xgboost' package: null
+            heart_disease: null
+            learner: null
+            gradient_booster: null
+            updater: null
+            grow_colmaker: null
+            train_param: null
+            n_estimators: null
+            learning_rate: null
+            max_depth: null
+            reg_lambda: null
+            subsample: null
+            colsample_bytree: null
+            colsample_bylevel: null
+            colsample_bynode: null
+        def `test_default_parameters_reg`:
+            Missing 'xgboost' package: null
+            housing: null
+            learner: null
+            gradient_booster: null
+            updater: null
+            grow_colmaker: null
+            train_param: null
+            n_estimators: null
+            learning_rate: null
+            max_depth: null
+            reg_lambda: null
+            subsample: null
+            colsample_bytree: null
+            colsample_bylevel: null
+            colsample_bynode: null
+    class `TestCatGBLearnerEditor`:
+        def `test_arguments`:
+            n_estimators: null
+            learning_rate: null
+            max_depth: null
+            reg_lambda: null
+            colsample_bylevel: null
+            random_state: null
+        def `test_learner_parameters`:
+            Missing 'catboost' package: null
+            Method: null
+            Gradient Boosting (catboost): null
+            Number of trees: null
+            Learning rate: null
+            Replicable training: null
+            Yes: null
+            Maximum tree depth: null
+            Regularization strength: null
+            Fraction of features for each tree: null
+        def `test_default_parameters_cls`:
+            Missing 'catboost' package: null
+            heart_disease: null
+            iterations: null
+            depth: null
+            l2_leaf_reg: null
+            rsm: null
+        def `test_default_parameters_reg`:
+            Missing 'catboost' package: null
+            housing: null
+            iterations: null
+            depth: null
+            l2_leaf_reg: null
+            rsm: null
+    class `TestOWGradientBoosting`:
+        def `setUp`:
+            auto_apply: null
+            n_estimators: null
+            learning_rate: null
+            max_depth: null
+            min_samples_split: null
+        def `test_xgb_params`:
+            Missing 'xgboost' package: null
+            n_estimators: null
+            learning_rate: null
+            max_depth: null
+            reg_lambda: null
+        def `test_missing_lib`:
+            orange: null
+            xgboost: null
+            catboost: null
+            method_index: null
+    __main__: null
+widgets/model/tests/test_owknn.py:
+    class `TestOWKNNLearner`:
+        def `setUp`:
+            auto_apply: null
+            metric: null
+            weights: null
+            n_neighbors: null
+widgets/model/tests/test_owlinearregression.py:
+    class `TestOWLinearRegression`:
+        def `setUp`:
+            auto_apply: null
+widgets/model/tests/test_owloadmodel.py:
+    class `TestOWLoadModel`:
+        def `setUp`:
+            iris: null
+            .pkcls: null
+        def `test_browse_file_opens_file`:
+            AnyQt.QtWidgets.QFileDialog.getOpenFileName: null
+            *.pkcls: null
+        def `test_select_file`:
+            pickle.load: null
+            .pkcls: null
+            \\: null
+            /: null
+        def `test_load_error`:
+            AnyQt.QtWidgets.QFileDialog.getOpenFileName: null
+            *.pkcls: null
+            pickle.load: null
+            last_path: null
+            foo: null
+        def `test_no_last_path`:
+            recent_paths: null
+        def `test_open_moved_workflow`:
+            Orange.widgets.widget.OWWidget.workflowEnv: null
+            basedir: null
+            pickle.load: null
+            temp/models: null
+            models: null
+            recent_paths: null
+            \\: null
+            /: null
+    class `TestOWLoadModelDropHandler`:
+        def `test_canDropFile`:
+            test.pkcls: null
+            test.txt: null
+        def `test_parametersFromFile`:
+            test.pkcls: null
+            recent_paths: null
+    __main__: null
+widgets/model/tests/test_owlogisticregression.py:
+    class `LogisticRegressionTest`:
+        def `test_coef_table_single`:
+            titanic: null
+        def `test_coef_table_multiple`:
+            zoo: null
+    class `TestOWLogisticRegression`:
+        def `setUp`:
+            auto_apply: null
+            penalty: null
+            C: null
+        def `test_output_coefficients`:
+            Data: null
+        def `test_domain_with_more_values_than_table`:
+            iris: null
+            Data: null
+        def `test_coefficients_one_value`:
+            a: null
+            b: null
+            c: null
+            yes: null
+            no: null
+            Data: null
+        def `test_target_with_nan`:
+            iris: null
+            Data: null
+            Coefficients: null
+        def `test_class_weights`:
+            iris: null
+            Data: null
+            balanced: null
+        def `test_no_penalty`:
+            none: null
+            N/A: NN
+            l2: null
+            C=1: null
+widgets/model/tests/test_ownaivebayes.py:
+    class `TestOWNaiveBayes`:
+        def `setUp`:
+            auto_apply: null
+widgets/model/tests/test_owneuralnetwork.py:
+    class `TestOWNeuralNetwork`:
+        def `setUp`:
+            ignore: null
+            .*: null
+            auto_apply: null
+        def `test_migrate_setting`:
+            alpha_index: null
+        def `test_no_layer_warning`:
+            10,: null
+widgets/model/tests/test_owrandomforest.py:
+    class `TestOWRandomForest`:
+        def `setUp`:
+            auto_apply: null
+            n_estimators: null
+            min_samples_split: null
+        def `test_parameters_checked`:
+            max_features: null
+            max_depth: null
+        def `test_parameters_unchecked`:
+            max_features: null
+            sqrt: null
+            random_state: null
+            max_depth: null
+            min_samples_split: null
+        def `test_class_weights`:
+            iris: null
+            Data: null
+            balanced: null
+    __main__: null
+widgets/model/tests/test_owrulesclassification.py:
+    class `TestOWRulesClassification`:
+        def `setUp`:
+            auto_apply: null
+            Evaluation measure: Ocena kvalitete pravila
+            Beam width: Širina snopa
+            Minimum rule coverage: Najmanjše število pokritih primerov
+            Maximum rule length: Največja dolžina pravila
+        def `test_sparse_data`:
+            iris: null
+            Data: null
+        def `test_out_of_memory`:
+            iris: null
+            Orange.widgets.model.owrules.CustomRuleLearner.__call__: null
+            Data: null
+        def `test_default_rule`:
+            zoo: null
+            Data: null
+widgets/model/tests/test_owsavemodel.py:
+    class `OWSaveTestBase`:
+        def `setUp`:
+            iris: null
+    __main__: null
+widgets/model/tests/test_owsgd.py:
+    class `TestOWSGD`:
+        def `setUp`:
+            ignore: null
+            .*: null
+            auto_apply: null
+            loss: null
+            classification: null
+            epsilon: null
+            regression: null
+            penalty: null
+            alpha: null
+            l1_ratio: null
+            learning_rate: null
+            eta0: null
+            power_t: null
+widgets/model/tests/test_owstack.py:
+    class `TestOWStackedLearner`:
+        def `setUp`:
+            auto_apply: null
+            iris: null
+        def `test_input_data`:
+            Data: null
+        def `test_output_learner`:
+            Learners: null
+            Learner: null
+            Does not initialize the learner output: null
+            Does not send a new learner instance on `Apply`.: null
+        def `test_output_model`:
+            Learners: null
+            Data: null
+widgets/model/tests/test_owsvm.py:
+    class `TestOWSVMClassification`:
+        def `setUp`:
+            auto_apply: null
+            C: null
+            gamma: null
+            coef0: null
+            degree: null
+            tol: null
+            max_iter: null
+        def `test_parameters_unchecked`:
+            max_iter: null
+        def `test_parameters_svm_type`:
+            nu: null
+        def `test_sparse_warning`:
+            iris: null
+            Data: null
+widgets/model/tests/test_tree.py:
+    class `TestOWClassificationTree`:
+        def `setUp`:
+            auto_apply: null
+            max_depth: null
+            min_internal: null
+            min_samples_split: null
+            min_leaf: null
+            min_samples_leaf: null
+        def `test_sparse_data_classification`:
+            iris: null
+            Data: null
+            Model: null
+        def `test_sparse_data_regression`:
+            housing: null
+            Data: null
+            Model: null
+widgets/report/tests/test_report.py:
+    def `get_owwidgets`:
+        ow: null
+        .py: null
+        {}.{}: null
+        .: null
+        'Failed to import module: ': null
+        OW: null
+        name: null
+        send_report: null
+    Orange.widgets.data: null
+    Orange.widgets.visualize: null
+    Orange.widgets.model: null
+    class `TestReportWidgets`:
+        def `test_report_widgets_model`:
+            titanic: null
+        def `test_report_widgets_data`:
+            zoo: null
+        def `test_report_widgets_evaluate`:
+            zoo: null
+            LR l2: null
+        def `test_report_widgets_unsupervised`:
+            zoo: null
+        def `test_report_widgets_unsupervised_dist`:
+            zoo: null
+        def `test_report_widgets_visualize`:
+            zoo: null
+        def `test_report_widgets_all`:
+            pyqt5: null
+            Segfaults on PyQt5: null
+    __main__: null
+widgets/tests/test_class_values_context_handler.py:
+    x: null
+    class `TestClassValuesContextHandler`:
+        def `setUp`:
+            c1: null
+            d1: null
+            abc: null
+            d2: null
+            def: null
+            d3: null
+            ghi: null
+            c2: null
+            d4: null
+            jkl: null
+        def `test_open_context`:
+            g: null
+            h: null
+            i: null
+            u: null
+            d1: null
+            d2: null
+        def `test_open_context_with_no_match`:
+            g: null
+            h: null
+            i: null
+            u: null
+            d1: null
+            d2: null
+            a: null
+            b: null
+            c: null
+widgets/tests/test_credentials.py:
+    class `TestCredentialManager`:
+        def `setUp`:
+            Orange: null
+        def `test_credential_manager`:
+            Orange: null
+            Foo: null
+        def `test_set_password`:
+            keyring.set_password: null
+            Orange.widgets.credentials.log.exception: null
+        def `test_delete_password`:
+            keyring.delete_password: null
+            Orange.widgets.credentials.log.exception: null
+        def `test_get_password`:
+            keyring.get_password: null
+            Orange.widgets.credentials.log.exception: null
+widgets/tests/test_domain_context_handler.py:
+    x: null
+    class `TestDomainContextHandler`:
+        def `setUp`:
+            c1: null
+            d1: null
+            abc: null
+            d2: null
+            def: null
+            d3: null
+            ghi: null
+            c2: null
+            d4: null
+            jkl: null
+        def `test_encode_domain_with_match_none`:
+            c1: null
+            d1: null
+            d2: null
+            d3: null
+            c2: null
+            d4: null
+        def `test_encode_domain_with_match_class`:
+            c1: null
+            d1: null
+            d2: null
+            d3: null
+            ghi: null
+            c2: null
+            d4: null
+        def `test_encode_domain_with_match_all`:
+            c1: null
+            d1: null
+            abc: null
+            d2: null
+            def: null
+            d3: null
+            ghi: null
+            c2: null
+            d4: null
+            jkl: null
+        def `test_match_returns_1_if_everything_matches`:
+            d1: null
+            d4: null
+        def `test_match_returns_zero_on_incompatible_context`:
+            u: null
+            d1: null
+        def `test_clone_context`:
+            u: null
+            d1: null
+            c1: null
+            text: null
+            with_metas: null
+            required: null
+        def `test_open_context`:
+            u: null
+            d1: null
+            d2: null
+        def `test_open_context_with_imperfect_match`:
+            u: null
+            d1: null
+            c1: null
+        def `test_open_context_not_first_match`:
+            u: null
+            d1: null
+            c1: null
+        def `test_open_context_with_no_match`:
+            u: null
+            text: null
+        def `test_filter_value`:
+            value: null
+            def `test_filter`:
+                value: null
+            d1: null
+            c1: null
+            abcd: null
+        def `test_filter_value_dict`:
+            value: null
+            def `test_filter`:
+                value: null
+            d1: null
+            c1: null
+            abcd: null
+        def `test_backward_compatible_params`:
+            always: null
+widgets/tests/test_gui.py:
+    class `TestDoubleSpin`:
+        def `test_checked_extension`:
+            some_param: null
+            some_option: null
+    class `TestListModel`:
+        def `setUp`:
+            foo: null
+        def `test_select_callback`:
+            abc: null
+        def `test_select_callfront`:
+            abc: null
+            b: null
+    class `ComboBoxTest`:
+        def `test_set_initial_value`:
+            abc: null
+            foo: null
+        def `test_warn_value_type`:
+            Orange.widgets.gui.gui_comboBox: null
+            foo: null
+    class `TestRankModel`:
+        def `test_argsort`:
+            Bertha: null
+            daniela: null
+            ann: null
+            Cecilia: null
+widgets/tests/test_matplotlib_export.py:
+    def `add_intro`:
+        import matplotlib.pyplot as plt\n: null
+        from numpy import array\n: null
+        plt.clf(): null
+    class `TestScatterPlot`:
+        def `test_owscatterplot_ignore_empty`:
+            iris: null
+            plt.scatter: null
+        def `test_scatterplot_simple`:
+            w: null
+            plt.scatter: null
+widgets/tests/test_perfect_domain_context_handler.py:
+    x: null
+    class `TestPerfectDomainContextHandler`:
+        def `setUp`:
+            c1: null
+            d1: null
+            abc: null
+            d2: null
+            def: null
+            d3: null
+            ghi: null
+            c2: null
+            d4: null
+            jkl: null
+        def `test_encode_domain_simple`:
+            c1: null
+            d1: null
+            d2: null
+            d3: null
+            c2: null
+            d4: null
+        def `test_encode_domain_match_values`:
+            c1: null
+            d1: null
+            abc: null
+            d2: null
+            def: null
+            d3: null
+            ghi: null
+            c2: null
+            d4: null
+            jkl: null
+        def `test_encode_setting`:
+            d1: null
+            d4: null
+    class `SimpleWidget`:
+        foo: null
+widgets/tests/test_settings_handler.py:
+    class `MigrationsTestCase`:
+        def `test_migrate_str_to_variable`:
+            foo: null
+            baz: null
+            qux: null
+            quuux: null
+widgets/tests/test_widgets_outputs.py:
+    class `TestWidgetOutputs`:
+        def `test_outputs`:
+            \\n\s+self.send\("([^"]*)": null
+            .: null
+            utf-8: null
+            - {} ({}): null
+            ', ': null
+            Some widgets send to undeclared outputs:\n: null
+            \n: null
+widgets/tests/test_workflows.py:
+    def `discover_workflows`:
+        .ows: null
+    class `TestWorkflows`:
+        SKIP_EXAMPLE_WORKFLOWS: null
+        Example workflows inflate coverage: null
+        def `test_scheme_examples`:
+            workflows: null
+            rb: null
+            Old workflow '{}' could not be loaded\n'{}': null
+        def `test_examples_order`:
+            orange3: null
+            !Testname: null
+            orangecontrib.any_addon.tutorials: null
+            exampletutorials: null
+            orangecontrib.other_addon.tutorials: null
+            orange.widgets.tutorials: null
+            000-Orange3: null
+widgets/unsupervised/tests/test_owcorrespondence.py:
+    class `TestOWCorrespondence`:
+        def `setUp`:
+            titanic: null
+        def `test_no_data`:
+            iris: null
+        def `test_data_values_in_column`:
+            a: null
+            b: null
+            t: null
+            f: null
+            c: null
+            y: null
+            n: null
+            d: null
+            k: null
+            l: null
+            z: null
+            yyyy: null
+            klkk: null
+        def `test_data_one_value_zero`:
+            a: null
+            0: null
+        def `test_no_discrete_variables`:
+            a: null
+            iris: null
+widgets/unsupervised/tests/test_owdbscan.py:
+    class `TestOWDBSCAN`:
+        def `setUp`:
+            iris: null
+        def `test_cluster`:
+            Cluster: Gruča
+            DBSCAN Core: Jedro DBSCAN-a
+        def `test_unique_domain`:
+            Cluster: Gruča
+            Cluster (1): Gruča (1)
+        def `test_sparse_csr_data`:
+            Cluster: Gruča
+            DBSCAN Core: Jedro DBSCAN-a
+        def `test_sparse_csc_data`:
+            Cluster: Gruča
+            DBSCAN Core: Jedro DBSCAN-a
+        def `test_get_kth_distances`:
+            euclidean: null
+        def `test_titanic`:
+            titanic: null
+        def `test_missing_data`:
+            Cluster: Gruča
+        def `test_normalize_data`:
+            heart_disease: null
+            eps: null
+            min_samples: null
+            metric: null
+            euclidean: null
+    __main__: null
+widgets/unsupervised/tests/test_owdistancefile.py:
+    class `TestOWDistanceFile`:
+        def `test_non_square`:
+            xlsx_files/distances_nonsquare.xlsx: null
+            xlsx_files/distances_with_nans.xlsx: null
+        def `test_nan_to_num`:
+            xlsx_files/distances_with_nans.xlsx: null
+    class `TestOWDistanceFileDropHandler`:
+        def `test_canDropFile`:
+            test.dst: null
+            test.xlsx: null
+            test.bin: null
+        def `test_parametersFromFile`:
+            test.dst: null
+            recent_paths: null
+widgets/unsupervised/tests/test_owdistancemap.py:
+    class `TestOWDistanceMap`:
+        def `setUpClass`:
+            Distances: null
+    __main__: null
+widgets/unsupervised/tests/test_owdistancematrix.py:
+    class `TestOWDistanceMatrix`:
+        def `setUp`:
+            iris: null
+        def `test_set_distances`:
+            ab: null
+            def: null
+        def `test_context_attribute`:
+            None: null
+            Enumerate: null
+        def `test_unconditional_commit_on_new_signal`:
+            now: null
+        def `test_labels`:
+            xy: null
+            s: null
+            Bill: null
+            Cynthia: null
+            Demi: null
+            Fred: null
+            George: null
+            9: null
+        def `test_num_meta_labels_w_nan`:
+            xy: null
+            s: null
+            a: null
+            b: null
+            1: null
+            ?: null
+        def `test_choose_label`:
+            xyz: null
+            t: null
+            m: null
+            abc: null
+            a: null
+            b: null
+            c: null
+        def `test_non_square_labels`:
+            aa: null
+            bb: null
+            cc: null
+            dd: null
+            ee: null
+            2: null
+        def `test_migrate_settings_v1_and_use_them`:
+            __version__: null
+            None: null
+            Enumerate: null
+            sepal length: null
+            sepal width: null
+            petal length: null
+            petal width: null
+            iris: null
+            context_settings: null
+        def `test_square_settings`:
+            ab: null
+    __main__: null
+widgets/unsupervised/tests/test_owdistances.py:
+    class `TestDistanceRunner`:
+        def `setUpClass`:
+            iris: null
+            zoo: null
+    class `TestOWDistances`:
+        def `setUp`:
+            iris: null
+            titanic: null
+        def `test_distance_combo`:
+            at {metricdef.name}: null
+        def `test_jaccard_messages`:
+            heart_disease: null
+        def `test_too_big_array`:
+            at {exc}: null
+        def `test_migrate_3_to_4`:
+            __version__: null
+            at {old} to {MetricDefs[new].name}: null
+        def `test_limit_mahalanobis`:
+            {i}: null
+        def `test_non_binary_in_metas`:
+            zoo: null
+            name: null
+            legs: null
+    __main__: null
+widgets/unsupervised/tests/test_owhierarchicalclustering.py:
+    class `TestOWHierarchicalClustering`:
+        def `setUpClass`:
+            Distances: null
+        def `_compare_selected_annotated_domains`:
+            Other: Drugo
+        def `test_annotation_settings_retrieval`:
+            Enumeration: Številčenje
+            None: Brez
+            Name: Ime
+        def `test_infinite_distances`:
+            a: null
+            b: null
+            y: null
+            yy: null
+            ignore: null
+            .*: null
+        def `test_column_distances`:
+            cluster: Gruča
+            sepal width: null
+            petal length: null
+            sepal length: null
+            petal width: null
+widgets/unsupervised/tests/test_owkmeans.py:
+    class `TestClusterTableModel`:
+        def `test_model`:
+            bad: null
+            another bad: null
+            NA: NN
+            0.250: null
+            4: null
+    class `TestOWKMeans`:
+        def `setUp`:
+            auto_commit: null
+            version: null
+            heart_disease: null
+        def `test_migrate_version_1_settings`:
+            auto_apply: null
+        def `test_use_cache`:
+            _compute_clustering: null
+            k: null
+        def `test_centroids_on_output`:
+            heart_disease centroids: centroidi heart_disease
+        def `test_centroids_domain_on_output`:
+            heart_disease: null
+            at attribute '{attr.name}': null
+            centroids: centroidi
+        class `KMeansFail`:
+            def `fit`:
+                n_clusters: null
+                k={} fails: null
+        def `test_optimization_fails`:
+            Orange.widgets.unsupervised.owkmeans.KMeans: null
+            set_scores: null
+        def `test_run_fails`:
+            Orange.widgets.unsupervised.owkmeans.KMeans: null
+        def `test_select_best_row`:
+            housing: null
+            error: null
+        def `test_normalize_sparse`:
+            Orange.widgets.unsupervised.owkmeans.Normalize: null
+        def `test_report`:
+            report_items: null
+            report_data: null
+            report_table: null
+            selected_row: null
+            Number of clusters: Število gruč
+            Optimization: Optimizacija
+        def `test_silhouette_column`:
+            Orange.widgets.unsupervised.owkmeans.SILHOUETTE_MAX_SAMPLES: null
+            Silhouette: Silhuete
+        def `test_do_not_recluster_on_same_data`:
+            now: null
+        def `test_correct_smart_init`:
+            _compute_clustering: null
+            init: null
+            k-means++: null
+            random: null
+    __main__: null
+widgets/unsupervised/tests/test_owlouvain.py:
+    class `TestOWLouvain`:
+        def `setUp`:
+            auto_commit: null
+            iris: null
+        def `test_clusters_ordered_by_size`:
+            Cluster: Gruča
+        def `test_empty_dataset`:
+            meta_var: null
+        def `test_do_not_recluster_on_same_data`:
+            _invalidate_output: null
+        def `test_only_recluster_when_necessary_pca_components_change`:
+            _invalidate_output: null
+        def `test_normalize_data`:
+            Orange.preprocess.Normalize: null
+        def `test_graph_output`:
+            graph: null
+        def `test_migrate_settings`:
+            context_settings: null
+            __version__: null
+            apply_pca: null
+            k_neighbors: null
+            metric_idx: null
+            normalize: null
+            pca_components: null
+            resolution: null
+widgets/unsupervised/tests/test_owmanifoldlearning.py:
+    class `TestOWManifoldLearning`:
+        def `setUpClass`:
+            iris: null
+        def `setUp`:
+            auto_apply: null
+        def `test_sparse_data`:
+            iris: null
+        def `test_metrics`:
+            t-SNE: null
+        def `test_unique_domain`:
+            MDS: null
+            C0: null
+            C0 (1): null
+        def `test_singular_matrices`:
+            a: null
+            b: null
+            c: null
+            0: null
+            1: null
+        def `test_out_of_memory`:
+            iris: null
+            Orange.projection.manifold.MDS.__call__: null
+            Data: null
+        def `test_unconditional_commit_on_new_signal`:
+            now: null
+widgets/unsupervised/tests/test_owmds.py:
+    class `TestOWMDS`:
+        def `setUpClass`:
+            Distances: null
+            ..: null
+            datasets: null
+        def `setUp`:
+            __version__: null
+            max_iter: null
+            initialization: null
+            slovenian-towns.dst: null
+        def `test_plot_once`:
+            heart_disease: null
+        def `test_out_of_memory`:
+            Orange.projection.MDS.__call__: null
+            sys.excepthook: null
+        def `test_other_error`:
+            Orange.projection.MDS.__call__: null
+            sys.excepthook: null
+        def `test_distances_without_data_0`:
+            Distances: null
+        def `test_distances_without_data_1`:
+            Distances: null
+        def `test_migrate_settings_from_version_1`:
+            iris: null
+            petal length: null
+            petal width: null
+            sepal length: null
+            sepal width: null
+            __version__: null
+            color_value: null
+            shape_value: null
+            size_value: null
+            Stress: Napetost
+            label_value: null
+            autocommit: null
+            connected_pairs: null
+            initialization: null
+            jitter: null
+            label_only_selected: null
+            legend_anchor: null
+            max_iter: null
+            refresh_rate: null
+            symbol_opacity: null
+            symbol_size: null
+            context_settings: null
+            savedWidgetGeometry: null
+        def `test_attr_label_from_dist_matrix_from_file`:
+            label: null
+        def `test_attr_label_from_dist_matrix_from_data`:
+            zoo: null
+        def `test_attr_label_from_data`:
+            zoo: null
+        def `test_attr_label_matrix_and_data`:
+            zoo: null
+        def `test_saved_matrix_and_data`:
+            label: null
+        def `test_matrix_columns_tooltip`:
+            sepal length: null
+        def `test_matrix_columns_default_label`:
+            labels: null
+        def `test_update_stress`:
+            {expected:.3f}: null
+            -: null
+    class `TestOWMDSRunner`:
+        def `setUpClass`:
+            iris: null
+        def `test_run_mds`:
+            Running...: Tečem...
+    __main__: null
+widgets/unsupervised/tests/test_owpca.py:
+    class `TestOWPCA`:
+        def `setUp`:
+            iris: null
+        def `test_constant_data`:
+            ignore: null
+        def `test_migrate_settings_limits_components`:
+            ncomponents: null
+        def `test_migrate_settings_changes_variance_covered_to_int`:
+            variance_covered: null
+            nan: null
+        def `test_unique_domain_components`:
+            components: komponente
+            components (1): komponente (1)
+        def `test_variance_attr`:
+            variance: null
+        def `test_all_components_continuous`:
+            datasets/cyber-security-breaches.tab: null
+            Some variables aren't of type ContinuousVariable: null
+        def `test_normalize_data`:
+            Normalize: null
+        def `test_do_not_mask_features`:
+            iris.tab: null
+    __main__: null
+widgets/unsupervised/tests/test_owsavedistances.py:
+    class `OWSaveTestBase`:
+        def `setUp`:
+            iris: null
+        def `_save_and_load`:
+            .dst: null
+        def `test_save_part_labels_as_table`:
+            rows: vrsticah
+            columns: stolpcih
+            failed when labels in {labels_in}: napaka, ko so podatkih v {labels_in}
+        def `test_save_trivial_labels`:
+            label: null
+        def `test_nonsquare`:
+            .xlsx: null
+        def `test_send_report`:
+            test.dst: null
+    __main__: null
+widgets/unsupervised/tests/test_owsom.py:
+    def `_patch_recompute_som`:
+        def `patched`:
+            winner_from_weights: null
+            _recompute_som: null
+    class `TestOWSOM`:
+        def `setUp`:
+            iris: null
+        def `test_requires_continuous`:
+            heart_disease: null
+            zoo: null
+        def `test_missing_all_data`:
+            heart_disease: null
+        def `test_single_row_data`:
+            heart_disease: null
+        def `test_sparse_data`:
+            from_table: null
+        def `test_attr_color_change`:
+            heart_disease: null
+            gender: null
+            age: null
+        def `test_get_color_column`:
+            heart_disease: null
+            rest ECG: null
+            gender: null
+            max HR: null
+            age: null
+        def `test_invalidated`:
+            heart_disease: null
+    __main__: null
+widgets/unsupervised/tests/test_owtsne.py:
+    class `TestOWtSNE`:
+        def `setUpClass`:
+            Data: null
+        def `setUp`:
+            Orange.projection.manifold.TSNE: null
+            Orange.projection.manifold.TSNEModel: null
+            multiscale: null
+            Stage name: null
+            STG1: null
+            STG2: null
+            GeneName: null
+        def `tearDown`:
+            stop called on unstarted patcher: null
+        def `test_wrong_input`:
+            STG1: null
+        def `test_input`:
+            STG1: null
+            STG2: null
+        def `test_normalize_data`:
+            Orange.preprocess.preprocess.Normalize: null
+        def `test_exaggeration_is_passed_through_properly`:
+            Orange.projection.manifold.TSNEModel.optimize: null
+            def `_check_exaggeration`:
+                exaggeration: null
+        def `test_modified_info_message_behaviour`:
+            The modified info message should be hidden by default: null
+            'The modified info message should be hidden even after toggling ': null
+            options if no data is on input: null
+            'The modified info message should be hidden after the widget ': null
+            computes the embedding: null
+            'The modified info message should be hidden when reloading the ': null
+            same data set and no previous messages were shown: null
+            'The modified info message should be shown when a setting is ': null
+            changed, but the embedding is not recomputed: null
+            housing: null
+            The information message was not cleared on new data: null
+            The information message was not cleared on no data: null
+        def `test_invalidation_flow`:
+            '#46befa': null
+            brush: null
+            '#000000': null
+    class `TestTSNERunner`:
+        def `setUpClass`:
+            iris: null
+        def `test_run`:
+            Computing PCA...: Računam PCA...
+            Preparing initialization...: Pripravljam začetno stanje...
+            Finding nearest neighbors...: Iščem najbližje sosede...
+            Running optimization...: Optimizacija teče...
+    __main__: null
+widgets/utils/localization/tests/test_localization.py:
+    class `TestEn`:
+        def `test_pl`:
+            cat: null
+            cats: null
+            cat|cats: null
+    __main__: null
+widgets/utils/save/tests/test_owsavebase.py:
+    class `SaveWidgetsTestBaseMixin`:
+        def `test_input_handler`:
+            Widget defines no inputs: null
+            widget has multiple inputs; input handler can't be tested: null
+        def `test_filters`:
+            Widget defines no filters: null
+    class `TestOWSaveBaseWithWriters`:
+        class `OWSaveMockWriter`:
+            Mock save: null
+            .csv: null
+            csv (*.csv): null
+        def `test_no_data_no_save`:
+            foo.tab: null
+        def `test_save_calls_writer`:
+            foo: null
+        def `test_base_methods`:
+            ~{os.sep}: null
+        def `assertPathEqual`:
+            win32: null
+            \\: null
+            /: null
+        def `test_open_moved_workflow`:
+            os.path.exists: null
+            /home/u/orange/a/b: null
+            /foo/bar: null
+            c.foo: null
+            Orange.widgets.widget.OWWidget.workflowEnv: null
+            a/b: null
+            /a/d: null
+            /foo/bar/c.foo: null
+            .: null
+            basedir: null
+            /home/u/orange/: null
+            /home/u/orange/a/b/c.foo: null
+            a/d: null
+            /home/u/orange/a/d: null
+            /home/u/orange/a/d/c.foo: null
+            /home/u/orange/c.foo: null
+        def `test_move_workflow`:
+            Orange.widgets.widget.OWWidget.workflowEnv: null
+            basedir: null
+            /home/u/orange/: null
+            /home/u/orange/a/b/c.foo: null
+            /home/u/orange/a/b: null
+            a/b/: null
+            c.foo: null
+            /tmp/u/work/: null
+            /tmp/u/work: null
+            /home/u/orange: null
+            /home/u/orange/a/b/: null
+            /tmp/u/work/a/b/c.foo: null
+            /tmp/u/work/a/b/: null
+            /home/u/orange/c.foo: null
+            .: null
+        def `test_migrate_pre_relative_settings`:
+            os.path.exists: null
+            /a/b: null
+            /a/b/c.foo: null
+            c.foo: null
+        def `test_save_button_label`:
+            c.foo: null
+            ' c.foo': null
+        def `test_invalid_filter`:
+            class `OWSaveNoWriter`:
+                Mock save: null
+                csv (*.csv): null
+            Unsupported format (*.foo): null
+            test.foo: null
+            /home/u/orange/a/b/c.csv: null
+            csv (*.csv): null
+        def `test_default_filter`:
+            class `OWSave`:
+                Mock save: null
+                csv (*.csv): null
+                txt (*.txt): null
+            csv (*.csv): null
+    class `TestOWSaveBase`:
+        def `setUp`:
+            class `OWSaveMockWriter`:
+                Mock save: null
+                csv (*.csv): null
+        def `test_no_data_no_save`:
+            foo.tab: null
+        def `test_base_methods`:
+            ~{os.sep}: null
+        def `test_default_filter`:
+            class `OWSave`:
+                Mock save: null
+                csv (*.csv): null
+                txt (*.txt): null
+        def `test_paths_win`:
+            win: null
+            windows path tests: null
+            class `OWSave`:
+                Mock save: null
+                csv (*.csv): null
+                txt (*.txt): null
+            C:/Temp: null
+            C:/Temp/abc.csv: null
+            C:/Temp/Project/abc.csv: null
+            C:/Temp/: null
+            c:\\Temp\\Project\\abc.csv: null
+            c:\\Temp: null
+            c:/Temp/Project\\abc.csv: null
+            basedir: null
+            C:/Folder/abc.csv: null
+            C:/Temp/Project: null
+            C:\\Temp\\Project: null
+            C:\\Temp\\abc.csv: null
+        def `test_paths_unix`:
+            class `OWSave`:
+                Mock save: null
+                csv (*.csv): null
+                txt (*.txt): null
+            /temp: null
+            /temp/abc.csv: null
+            /temp/project/abc.csv: null
+            /temp/: null
+            basedir: null
+            /folder/abc.csv: null
+            /temp/project: null
+    class `TestOWSaveUtils`:
+        def `test_replace_extension`:
+            class `OWMockSaveBase`:
+                Tab delimited (*.tab): null
+                Compressed tab delimited (*.gz.tab): null
+                Comma separated (*.csv): null
+                Compressed comma separated (*.csv.gz): null
+                Excel File (*.xlsx): null
+            /bing.bada.boom/foo.1942.tab: null
+            .tab: null
+            .tab.gz: null
+            /bing.bada.boom/foo.1942.tab.gz: null
+            .xlsx: null
+            /bing.bada.boom/foo.1942.xlsx: null
+            foo.tab.gz: null
+            foo.tab: null
+            .csv: null
+            foo.csv: null
+            .csv.gz: null
+            foo.csv.gz: null
+            /bing.bada.boom/foo: null
+        def `test_extension_from_filter`:
+            Description (*.ext): null
+            .ext: null
+            Description (*.foo.ba): null
+            .foo.ba: null
+            Description (.ext): null
+            Description (.foo.bar): null
+            .foo.bar: null
+    __main__: null
+widgets/utils/tests/test_annotated_data.py:
+    class `TestAnnotatedData`:
+        def `setUp`:
+            zoo: null
+        def `test_cascade_annotated_tables`:
+            {} ({}): null
+        def `test_cascade_annotated_tables_with_missing_middle_feature`:
+            {ANNOTATED_DATA_FEATURE_NAME} (3): null
+            {} ({}): null
+        def `test_cascade_annotated_tables_with_missing_annotated_feature`:
+            {ANNOTATED_DATA_FEATURE_NAME} (3): null
+            {} ({}): null
+        def `test_create_groups_table_include_unselected`:
+            Selected: Izbrani podatki
+            Unselected: Neizbrani
+            G1: null
+            G2: null
+        def `test_create_groups_table_set_values`:
+            this: null
+            that: null
+            rest: null
+            Selected: Izbrani podatki
+widgets/utils/tests/test_colorgradientselection.py:
+    class `TestColorGradientSelection`:
+        def `test_setModel`:
+            A: null
+            B: null
+        def `test_center_changed`:
+            41: null
+widgets/utils/tests/test_colorpalettes.py:
+    class `PaletteTest`:
+        def `test_copy`:
+            custom: null
+            c123: null
+        def `test_qcolors`:
+            custom: null
+            c123: null
+    class `IndexPaletteTest`:
+        def `setUp`:
+            custom: null
+            c123: null
+    class `PatchedVariableTest`:
+        def `test_colors`:
+            x: null
+        def `test_palette`:
+            x: null
+        def `test_exclusive`:
+            x: null
+            colors: null
+            palette: null
+    class `PatchedDiscreteVariableTest`:
+        def `test_colors`:
+            a: null
+            F: null
+            M: null
+            colors: null
+            '#000102': null
+            '#030405': null
+            x: null
+            A: null
+            B: null
+            '#0a0b0c': null
+            '#0d0e0f': null
+            foo: null
+            d: null
+            r: null
+            e: null
+            k: null
+            C: null
+            '#0D0E0F': null
+            v{i}: null
+        def `test_colors_fallback_to_palette`:
+            a: null
+            F: null
+            M: null
+            palette: null
+            {i}: null
+        def `test_colors_default`:
+            a: null
+            F: null
+            M: null
+            {i}: null
+            colors: null
+            foo: null
+        def `test_colors_no_values`:
+            a: null
+        def `test_get_palette`:
+            a: null
+            M: null
+            F: null
+            palette: null
+            dark: null
+            colors: null
+            '#0a0b0c': null
+            '#0d0e0f': null
+        def `test_ignore_malfformed_atrtibutes`:
+            a: null
+            M: null
+            F: null
+            colors: null
+            foo: null
+            bar: null
+    class `PatchedContinuousVariableTest`:
+        def `test_colors`:
+            a: null
+            colors: null
+            '#010203': null
+            '#040506': null
+        def `test_colors_from_palette`:
+            a: null
+            rainbow_bgyr_35_85_c73: null
+            palette: null
+            diverging_bwr_40_95_c42: null
+        def `test_palette`:
+            rainbow_bgyr_35_85_c73: null
+            a: null
+            palette: null
+            from_colors: null
+            colors: null
+            '#0a0b0c': null
+            '#0d0e0f': null
+        def `test_proxy_has_separate_colors`:
+            abc: null
+    __main__: null
+widgets/utils/tests/test_combobox.py:
+    class `TestItemStyledComboBox`:
+        def `test_combobox`:
+            ...: null
+            1: null
+            Windings: null
+    class `TestTextEditCombo`:
+        def `test_texteditcombo`:
+            !!: null
+            BB: null
+            AA: null
+            CC: null
+            AB: null
+            BC: null
+            BBA: null
+            BCA: null
+        def `test_activate_editing_finished_emit_ordering`:
+            def `activated`:
+                activated: null
+            def `finished`:
+                finished: null
+            AA: null
+            finished: null
+            activated: null
+widgets/utils/tests/test_concurrent.py:
+    class `TestTask`:
+        def `setUp`:
+            ignore: null
+            `Task` has been deprecated: null
+            `submit_task` will be deprecated: null
+widgets/utils/tests/test_concurrent_example.py:
+    class `TestOWConcurrentWidget`:
+        def `setUpClass`:
+            Data: null
+        def `test_button_no_data`:
+            Start: null
+        def `test_button_with_data`:
+            Stop: null
+            Start: null
+        def `test_button_toggle`:
+            Resume: null
+        def `test_plot_once`:
+            heart_disease: null
+    __main__: null
+widgets/utils/tests/test_distmatrixmodel.py:
+    class `TestModel`:
+        def `test_header_data`:
+            abc: null
+            b: null
+            de: null
+            e: null
+    __main__: null
+widgets/utils/tests/test_domaineditor.py:
+    class `MockWidget`:
+        mock: null
+    class `DomainEditorTest`:
+        def `setUp`:
+            d1: null
+            x, y, z, ...: null
+            d2: null
+            1, 2, 3, ...: null
+            c1: null
+            d3: null
+            4, 3, 6, ...: null
+            s: null
+            t: null
+            xyzw: null
+            12345: null
+            4368: null
+        def `test_deduplication`:
+            foo: null
+            d1: null
+            d2: null
+            c1: null
+            d3: null
+            s: null
+            t: null
+            d2 (1): null
+            d2 (2): null
+            s (1): null
+            s (2): null
+            skip: izpusti
+    __main__: null
+widgets/utils/tests/test_graphicstextlist.py:
+    class `TestTextListWidget`:
+        def `test_setItems`:
+            Aa: null
+            Bb: null
+        def `test_orientation`:
+            x: null
+        def `test_alignment`:
+            a: null
+        def `test_tool_tips`:
+            A: null
+    class `TestUtils`:
+        def `test_scaled`:
+            scaled({size}, {const}): null
+            scaled({size}, {const}, Qt.KeepAspectRatioByExpanding): null
+widgets/utils/tests/test_headerview.py:
+    class `TestHeaderView`:
+        def `test_header`:
+            A: null
+widgets/utils/tests/test_itemmodels.py:
+    class `TestPyTableModel`:
+        def `test_data`:
+            1: null
+        def `test_setHeaderLabels`:
+            Col 1: null
+            Col 2: null
+    class `TestVariableListModel`:
+        def `setUpClass`:
+            gender: null
+            M: null
+            F: null
+            age: null
+            name: null
+            birth: null
+            Foo: null
+        def `test_placeholder`:
+            None: Brez
+            Bar: null
+        def `test_displayrole`:
+            age: null
+            None: Brez
+            Foo: null
+            gender: null
+            name: null
+            birth: null
+        def `test_tooltip`:
+            age: null
+            Numeric: Številska
+            gender: null
+            M: null
+            F: null
+            2: null
+            Categorical: Kategorična
+            name: null
+            Text: Besedilna
+            birth: null
+            Time: Časovna
+            foo: null
+            bar: null
+        def `test_other_roles`:
+            data: null
+    class `TestDomainModel`:
+        def `test_separators`:
+            abg: null
+            deh: null
+            ijf: null
+            foo: null
+        def `test_placeholder_placement`:
+            foo: null
+            bar: null
+            baz: null
+        def `test_subparts`:
+            abg: null
+            deh: null
+            ijf: null
+        def `test_filtering`:
+            abc: null
+            def: null
+            hidden: null
+        def `test_no_separators`:
+            abg: null
+            deh: null
+            ijf: null
+        def `test_read_only`:
+            abc: null
+            foo: null
+    class `TestContinuousPalettesModel`:
+        def `test_category_selection`:
+            Diverging: null
+            Linear: null
+        def `test_single_category`:
+            Diverging: null
+        def `test_data`:
+            Palettes: null
+            color_strip: null
+        def `test_select_flags`:
+            Palettes: null
+        def `testIndexOf`:
+            Palettes: null
+    class `TestPyListModelTooltip`:
+        def `test_tooltips_size`:
+            foo: null
+            bar: null
+            baz: null
+            footip: null
+            bartip: null
+            btip: null
+        def `test_tooltip_arg`:
+            ta: null
+            tb: null
+            foo: null
+            footip: null
+    class `TestTableModel`:
+        def `test_dense_data`:
+            postgres: null
+            mssql: null
+        def `test_local_dense_data`:
+            iris.tab: null
+        def `test_sparse_data`:
+            datasets/iris_basket.basket: null
+            sepal_length=1.5, sepal_width=5.3, petal_length=4.1, petal_width=2: null
+            Iris-setosa: null
+    __main__: null
+widgets/utils/tests/test_owbasesql.py:
+    UN: null
+    PASS: null
+    class `BrokenBackend`:
+        def `__init__`:
+            Error connecting to DB.: null
+    class `TestableSqlWidget`:
+        SQL: null
+        def `get_table`:
+            iris: null
+    class `TestOWBaseSql`:
+        def `setUp`:
+            host: null
+            port: null
+            DB: null
+            database: null
+            schema: null
+        def `test_connect`:
+            host: null
+            port: null
+            database: null
+            user: null
+            password: null
+            Host: Strežnik
+            Port: Vrata
+            Database: Baza
+            User name: Uporabniško ime
+    __main__: null
+widgets/utils/tests/test_owlearnerwidget.py:
+    class `TestOWBaseLearner`:
+        def `setUpClass`:
+            iris: null
+        def `test_error_on_learning`:
+            class `FailingLearner`:
+                def `__call__`:
+                    boom: null
+            class `OWFailingLearner`:
+                foo: null
+            Data: null
+        def `test_subclasses_do_not_share_outputs`:
+            class `WidgetA`:
+                A: null
+            class `WidgetB`:
+                B: null
+            class `WidgetC`:
+                C: null
+                class `Outputs`:
+                    test: null
+            test: null
+        def `test_send_backward_compatibility`:
+            class `WidgetA`:
+                A: null
+            Foo: null
+            Predictor: null
+            Bar: null
+        def `test_old_style_signals_on_subclass_backward_compatibility`:
+            class `WidgetA`:
+                A: null
+                set_data: null
+            inputs: null
+            outputs: null
+            A: null
+        def `test_persists_learner_name_in_settings`:
+            class `WidgetA`:
+                A: null
+            MyWidget: null
+        def `test_converts_sparse_targets_to_dense`:
+            class `WidgetLR`:
+                lr: null
+        def `test_invalid_number_of_targets`:
+            class `MockLearner`:
+                mock: null
+                classification: null
+            class `WidgetLR`:
+                lr: null
+            heart_disease: null
+            age: null
+            gender: null
+            chest pain: null
+            target: ciljne spremenljivke
+        def `test_default_name`:
+            class `TestLearner`:
+                Test: null
+            class `TestWidget`:
+                Test: null
+            Test: null
+            Foo: null
+            Bar: null
+            Frob: null
+            This is not a test: null
+            Blarg: null
+        def `test_preprocessor_warning`:
+            class `TestLearnerNoPreprocess`:
+                Test: null
+            class `TestWidgetNoPreprocess`:
+                Test: null
+            class `TestLearnerPreprocess`:
+                Test: null
+            class `TestWidgetPreprocess`:
+                Test: null
+            class `TestFitterPreprocess`:
+                Test: null
+            class `TestWidgetPreprocessFit`:
+                Test: null
+        def `test_multiple_sends`:
+            class `TestLearner`:
+                Test: null
+            class `TestWidget`:
+                Test: null
+            send: null
+widgets/utils/tests/test_slidergraph.py:
+    class `SimpleWidget`:
+        Simple widget: null
+        def `__init__`:
+            label1: null
+            label2: null
+    class `TestSliderGraph`:
+        def `test_init`:
+            label1: null
+            bottom: null
+            label2: null
+            left: null
+        def `test_plot`:
+            label1: null
+            bottom: null
+            label2: null
+            left: null
+        def `test_plot_selection_limit`:
+            label1: null
+            bottom: null
+            label2: null
+            left: null
+widgets/utils/tests/test_sql.py:
+    class `TestSQLDecorator`:
+        class `MockWidget`:
+            MockWidget: null
+            class `Inputs`:
+                Data: null
+        def `test_inputs_check_sql`:
+            Orange.widgets.utils.sql.Table: null
+            Orange.widgets.utils.state_summary.format_summary_details: null
+    __main__: null
+widgets/utils/tests/test_state_summary.py:
+    VarDataPair: null
+    variable: null
+    data: null
+    continuous_full: null
+    continuous_missing: null
+    rgb_full: null
+    r: null
+    g: null
+    b: null
+    rgb_missing: null
+    ints_full: null
+    2: null
+    3: null
+    4: null
+    ints_missing: null
+    time_full: null
+    time_missing: null
+    string_full: null
+    a: null
+    c: null
+    d: null
+    e: null
+    string_missing: null
+    class `TestUtils`:
+        def `test_details`:
+            zoo: null
+            'zoo: {len(data)} instances, ': null
+            {n_features} variables\n: null
+            'Features: {len(data.domain.attributes)} categorical ': null
+            (no missing values)\n: null
+            'Target: categorical\n': null
+            'Metas: string': null
+            housing: null
+            'housing: {len(data)} instances, ': null
+            'Features: {len(data.domain.attributes)} numeric ': null
+            'Target: numeric': null
+            heart_disease: null
+            'heart_disease: {len(data)} instances, ': null
+            'Features: {len(data.domain.attributes)} ': null
+            (7 categorical, 6 numeric) (0.2% missing values)\n: null
+            'Target: categorical': null
+            '{len(data)} instances, ': null
+            (10.0% missing values)\n: null
+            'Target: {len(data.domain.class_vars)} categorical\n': null
+            'Metas: {len(data.domain.metas)} categorical': null
+            (2 categorical, 1 numeric, 1 time) (5.0% missing values)\n: null
+            'Target: {len(data.domain.class_vars)} ': null
+            (1 categorical, 1 numeric)\n: null
+            'Metas: {len(data.domain.metas)} string': null
+            {len(data.domain.variables)} variables\n: null
+            'Features: {len(data.domain.attributes)} time ': null
+            'Features: {len(data.domain.variables)} categorical ': null
+            'Target: —': null
+            {len(data.domain.variables)} variable\n: null
+            'Features: categorical (no missing values)\n': null
+            '{len(data):n} instances, ': null
+            'Features: {len(data.domain.variables)} numeric \n': null
+            get_nan_frequency_attribute: null
+        def `test_multiple_summaries`:
+            zoo: null
+            'Data:<br>zoo: {len(data)} instances, ': null
+            {n_features_data} variables<br>: null
+            'Features: {len(data.domain.attributes)} categorical ': null
+            (no missing values)<br>: null
+            'Target: categorical<br>': null
+            'Metas: string<hr>': null
+            'Extra Data:<br>zoo: {len(extra_data)} instances, ': null
+            {n_features_extra_data} variables<br>: null
+            'Features: {len(extra_data.domain.attributes)} ': null
+            categorical (no missing values)<br>: null
+            'Metas: string': null
+            Data: null
+            Extra Data: null
+            'zoo: {len(data)} instances, ': null
+            'zoo: {len(extra_data)} instances, ': null
+            No data on output.<hr>: null
+            'Extra data:<br>zoo: {len(extra_data)} instances, ': null
+            No data on output.: null
+            Extra data: null
+            output: null
+    __main__: null
+widgets/utils/tests/test_textimport.py:
+    ,A,B,C: null
+    A: null
+    A, B, C, D\n: null
+    a, 1, 2, *\n: null
+    b, 2, 4, *: null
+    a\tb\n: null
+    class `WidgetsTests`:
+        def `test_options_widget`:
+            iso8859-1: null
+            a: null
+            b: null
+            c: null
+            delimiter-combo-box: null
+            custom-delimiter-edit: null
+            quote-edit-combo-box: null
+    __main__: null
+widgets/visualize/tests/test_owbarplot.py:
+    class `TestOWBarPlot`:
+        def `setUpClass`:
+            Data: null
+            titanic: null
+            housing: null
+            heart_disease: null
+        def `test_input_to_many_instances`:
+            Orange.widgets.visualize.owbarplot.MAX_INSTANCES: null
+        def `test_init_attr_values`:
+            None: (Brez)
+            (Same color): (Enaka barva)
+            age: null
+            diameter narrowing: null
+            sepal length: null
+            iris: null
+            MEDV: null
+        def `test_group_axis`:
+            bottom: null
+            iris: null
+        def `test_plot_data_subset`:
+            brushes: null
+        def `test_saved_workflow`:
+            cholesterol: null
+            chest pain: null
+            gender: null
+            thal: null
+        def `test_sparse_data`:
+            iris: null
+        def `test_hidden_vars`:
+            iris: null
+            hidden: null
+            sepal width: null
+        def `test_visual_settings`:
+            Helvetica: null
+            Fonts: null
+            Font family: null
+            Title: null
+            Font size: null
+            Italic: null
+            Axis title: null
+            Axis ticks: null
+            tickFont: null
+            Legend: null
+            Annotations: null
+            Foo: null
+            Figure: null
+            Gridlines: null
+            Show: null
+            left: null
+            Bottom axis: null
+            Vertical ticks: null
+            bottom: null
+            rotateTicks: null
+            Group axis: null
+        def `assertSelectedIndices`:
+            pens: null
+    __main__: null
+widgets/visualize/tests/test_owboxplot.py:
+    class `TestOWBoxPlot`:
+        def `setUpClass`:
+            iris: null
+            zoo: null
+            housing: null
+            titanic: null
+            heart_disease: null
+            Data: null
+        def `test_dont_show_hidden_attrs`:
+            iris: null
+            hidden: null
+            petal length: null
+        def `test_input_data_missings_disc_group_var`:
+            Data: null
+        def `test_input_data_missings_disc_no_group_var`:
+            cls: null
+            Data: null
+        def `test_apply_sorting_group`:
+            Data: null
+            sex: null
+            survived: null
+            age: null
+            status: null
+            thal: null
+            chest pain: null
+            major vessels colored: null
+            ST by exercise: null
+            max HR: null
+            exerc ind ang: null
+            slope peak exc ST: null
+            gender: null
+            rest ECG: null
+            rest SBP: null
+            cholesterol: null
+            fasting blood sugar > 120: null
+            diameter narrowing: null
+        def `test_apply_sorting_vars`:
+            Data: null
+            None: Brez
+            sex: null
+            survived: null
+            age: null
+            status: null
+            thal: null
+            chest pain: null
+            exerc ind ang: null
+            slope peak exc ST: null
+            gender: null
+            rest ECG: null
+            fasting blood sugar > 120: null
+            diameter narrowing: null
+        def `test_continuous_metas`:
+            str: null
+        def `test_label_overlap`:
+            chest pain: null
+            gender: null
+        def `test_empty_groups`:
+            datasets/cyber-security-breaches.tab: null
+            US State: null
+        def `test_sorting_disc_group_var`:
+            heart_disease: null
+            gender: null
+            chest pain: null
+        def `test_unconditional_commit_on_new_signal`:
+            commit: null
+        def `test_stretching`:
+            chest pain: null
+            gender: null
+        def `test_value_all_missing_for_group`:
+            a: null
+            v1: null
+            v2: null
+            v3: null
+            b: null
+            v4: null
+        def `test_valid_data_range`:
+            petal width: null
+            iris: null
+    __main__: null
+widgets/visualize/tests/test_owdistributions.py:
+    class `TestOWDistributions`:
+        def `setUp`:
+            iris: null
+        def `test_histogram_data`:
+            sepal length: null
+            iris: null
+        def `test_switch_cvar`:
+            foo: null
+            a: null
+            b: null
+        CI: null
+        def `test_disable_hide_bars`:
+            petal length: null
+            iris: null
+        def `test_hide_bars`:
+            petal length: null
+            iris: null
+            brush: null
+        def `test_sort_by_freq_no_split`:
+            heart_disease: null
+            gender: null
+            female: null
+            male: null
+        def `test_sort_by_freq_split`:
+            heart_disease: null
+            gender: null
+            rest ECG: null
+            female: null
+            normal: null
+            male: null
+            left vent hypertrophy: null
+    __main__: null
+widgets/visualize/tests/test_owfreeviz.py:
+    class `TestOWFreeViz`:
+        def `setUpClass`:
+            Data: null
+            heart_disease: null
+        def `test_number_of_targets`:
+            age: null
+            gender: null
+            chest pain: null
+        def `test_optimization`:
+            Stop: Stoj
+        def `test_optimization_cancelled`:
+            Resume: Nadaljuj
+        def `test_optimization_reset`:
+            Stop: Stoj
+        def `test_optimization_finish`:
+            Stop: Stoj
+            Start: Začni
+        def `test_optimization_no_data`:
+            Start: Začni
+        def `test_constant_data`:
+            titanic: null
+        def `test_output_components`:
+            component: null
+            freeviz-x: null
+            freeviz-y: null
+        def `test_discrete_attributes`:
+            zoo: null
+    class `TestOWFreeVizRunner`:
+        def `setUpClass`:
+            iris: null
+        def `test_run`:
+            Calculating...: Računam...
+    __main__: null
+widgets/visualize/tests/test_owheatmap.py:
+    class `TestOWHeatMap`:
+        def `setUpClass`:
+            Data: null
+        def `setUp`:
+            housing: null
+            titanic: null
+            brown-selected: null
+        def `test_information_message`:
+            heart_disease.tab: null
+        def `test_not_enough_data_settings_changed`:
+            ignore: null
+            Number of distinct clusters: null
+        def `test_cluster_column_on_all_zero_column`:
+            iris: null
+        def `test_empty_clusters`:
+            y: null
+            ignore: null
+            Number of distinct clusters: null
+        def `test_use_enough_colors`:
+            y: null
+        def `test_cls_with_single_instance`:
+            c1: null
+            c2: null
+            a: null
+            b: null
+        def `test_unconditional_commit_on_new_signal`:
+            now: null
+        def `test_saved_selection`:
+            iris: null
+        def `test_saved_selection_when_not_possible`:
+            iris: null
+            petal width: null
+            __version__: null
+            col_clustering_method: null
+            Clustering: null
+            selected_rows: null
+        def `_brown_selected_10`:
+            diau g: null
+        def `test_set_split_column_key`:
+            function: null
+        def `test_set_split_column_key_missing`:
+            function: null
+        def `test_palette_centering`:
+            y: null
+            center_palette: null
+        def `test_centering_threshold_change`:
+            y: null
+            diverging_bwr_40_95_c42: null
+        def `test_migrate_settings_v3`:
+            row_clustering: null
+            col_clustering: null
+        def `test_row_color_annotations`:
+            function: null
+        def `test_row_color_annotations_with_na`:
+            function: null
+            diau g: null
+        def `test_col_color_annotations`:
+            function: null
+            diau g: null
+        def `test_col_color_annotations_with_na`:
+            function: null
+            diau g: null
+        def `test_data_with_hidden`:
+            hidden: null
+    __main__: null
+widgets/visualize/tests/test_owlinearprojection.py:
+    class `TestOWLinearProjection`:
+        def `setUpClass`:
+            Data: null
+        def `test_bad_data`:
+            iris: null
+            class: null
+            a: null
+        def `test_no_data_for_lda`:
+            housing: null
+        def `test_data_no_cont_features`:
+            titanic: null
+        def `test_invalid_data`:
+            iris: null
+        def `test_migrate_settings_from_version_1`:
+            __version__: null
+            alpha_value: null
+            auto_commit: null
+            class_density: null
+            context_settings: null
+            iris: null
+            petal length: null
+            petal width: null
+            sepal length: null
+            sepal width: null
+            color_index: null
+            shape_index: null
+            size_index: null
+            variable_state: null
+            jitter_value: null
+            legend_anchor: null
+            point_size: null
+            savedWidgetGeometry: null
+        def `test_two_classes_dataset`:
+            heart_disease: null
+        def `test_unique_name`:
+            iris: null
+            C-y: null
+            C-x (1): null
+            C-y (1): null
+            Selected: Izbrani podatki
+    class `LinProjVizRankTests`:
+        def `setUpClass`:
+            iris: null
+        def `test_continuous_class`:
+            housing: null
+    __main__: null
+widgets/visualize/tests/test_owlineplot.py:
+    class `TestOWLinePLot`:
+        def `setUpClass`:
+            Data: null
+        def `setUp`:
+            titanic: null
+            housing: null
+        def `test_select_lines_enabled`:
+            Orange.widgets.visualize.owlineplot.SEL_MAX_INSTANCES: null
+        def `test_max_features`:
+            Orange.widgets.visualize.owlineplot.MAX_FEATURES: null
+        def `test_group_view`:
+            None: (Brez skupin)
+        def `test_plot_subset`:
+            show_range: null
+        def `test_plot_only_mean`:
+            show_range: null
+        def `test_sparse_data`:
+            iris: null
+        def `test_unconditional_commit_on_new_signal`:
+            now: null
+        def `test_visual_settings`:
+            Helvetica: null
+            Fonts: null
+            Font family: null
+            Title: null
+            Font size: null
+            Italic: null
+            Axis title: null
+            bottom: null
+            left: null
+            Axis ticks: null
+            tickFont: null
+            Legend: null
+            Annotations: null
+            Foo: null
+            x-axis title: null
+            Foo2: null
+            y-axis title: null
+            Foo3: null
+            Figure: null
+            Lines (missing value): null
+            Width: null
+            pen: null
+            Selected lines (missing value): null
+    __main__: null
+widgets/visualize/tests/test_owmosaic.py:
+    class `TestOWMosaicDisplay`:
+        def `setUpClass`:
+            Data: null
+        def `test_continuous_metas`:
+            c1: null
+            m: null
+        def `test_string_meta`:
+            m: null
+            meta: null
+        def `test_missing_values`:
+            c1: null
+            a: null
+            b: null
+            c: null
+            cls: null
+        def `test_keyerror`:
+            iris: null
+        def `test_combos_and_mosaic`:
+            iris: null
+        def `test_different_number_of_attributes`:
+            Orange.widgets.visualize.owmosaic.CanvasRectangle: null
+            Orange.widgets.visualize.owmosaic.QGraphicsItemGroup.addToGroup: null
+            01: null
+            abcd: null
+            {:04b}: null
+            variable: null
+        def `test_vizrank_receives_manual_change`:
+            Orange.widgets.visualize.owmosaic.MosaicVizRank.on_manual_change: null
+            iris.tab: null
+        def `test_selection_setting`:
+            iris.tab: null
+            titanic: null
+    class `MosaicVizRankTests`:
+        def `setUpClass`:
+            iris.tab: null
+        def `test_row_for_state`:
+            abcd: null
+            a, b, d: null
+        def `test_does_not_crash_cont_class`:
+            housing.tab: null
+        def `test_pause_continue`:
+            housing.tab: null
+        def `test_finished`:
+            iris.tab: null
+        def `test_max_attr_combo_1_disabling`:
+            iris.tab: null
+        def `test_attr_range`:
+            iris.tab: null
+            failed at max_attrs={vizrank.max_attrs}: null
+        def `test_nan_column`:
+            a: null
+            b: null
+            c: null
+        def `test_color_combo`:
+            titanic: null
+            (Pearson residuals): (Pearsonovi residuali)
+            Data: null
+        def `test_scores`:
+            status: null
+            sex: null
+            age: null
+            titanic: null
+        def `test_subset_data`:
+            titanic: null
+            housing: null
+        def `test_incompatible_subset`:
+            titanic: null
+        def `test_on_manual_change`:
+            iris.tab: null
+    __main__: null
+widgets/visualize/tests/test_ownomogram.py:
+    class `TestOWNomogram`:
+        def `setUpClass`:
+            heart_disease: null
+            titanic: null
+            datasets/lenses.tab: null
+        def `test_nomogram_lr_multiclass`:
+            ovr: null
+            liblinear: null
+        def `test_nomogram_with_instance_nb`:
+            status: null
+            age: null
+            sex: null
+        def `test_nomogram_with_instance_lr`:
+            status: null
+            age: null
+            sex: null
+        def `test_constant_feature_disc`:
+            d1: null
+            a: null
+            c: null
+            d2: null
+            b: null
+            cls: null
+            e: null
+            d: null
+        def `test_constant_feature_cont`:
+            d: null
+            a: null
+            b: null
+            c: null
+            cls: null
+        def `_test_helper_check_probability`:
+            'Probability: {}': Verjetnost: {}
+        def `_check_values`:
+            '{}: 100%': null
+            'Value: {}': null
+        def `test_tooltip`:
+            Some text.: null
+        def `test_adjust_scale`:
+            Orange.widgets.visualize.ownomogram.QGraphicsTextItem: null
+            var1: null
+            foo1: null
+            foo2: null
+            var2: null
+            foo3: null
+            foo4: null
+        def `test_reconstruct_domain`:
+            heart_disease: null
+        def `test_missing_class_value`:
+            iris: null
+        def `test_compute_value`:
+            iris: null
+    __main__: null
+widgets/visualize/tests/test_owprojectionwidget.py:
+    class `TestOWProjectionWidget`:
+        def `test_get_column`:
+            cont: null
+            disc: null
+            abcdefghijklmno: null
+            disc2: null
+            abc: null
+            disc3: null
+            string: null
+            foo: null
+            bar: null
+            baz: null
+        def `test_get_column_merge_infrequent`:
+            disc: null
+            abcdefghijklmno: null
+            disc2: null
+            abc: null
+            Other: Drugo
+        def `test_get_tooltip`:
+            v: null
+            3: null
+            1: null
+        def `test_get_palette`:
+            v: null
+            abc: null
+            abcdefghijklmn: null
+            a: null
+            c: null
+            d: null
+            h: null
+            n: null
+            Others: null
+            foo: null
+            bar: null
+    class `TestOWDataProjectionWidget`:
+        def `setUpClass`:
+            Data: null
+        def `test_annotation_with_nans`:
+            Selected: Izbrani podatki
+        def `test_invalid_subset`:
+            iris: null
+            titanic: null
+        def `test_sparse_data_reload`:
+            heart_disease: null
+        def `test_unconditional_commit_on_new_signal`:
+            now: null
+        def `test_model_update`:
+            iris: null
+            diverging_tritanopic_cwr_75_98_c20: null
+    __main__: null
+widgets/visualize/tests/test_owpythagorastree.py:
+    class `TestOWPythagorasTree`:
+        def `setUpClass`:
+            Tree: null
+            titanic: null
+            housing: null
+        def `test_changing_target_class_changes_node_coloring`:
+            def `_test`:
+                Colors did not change for %s data: null
+            classification: null
+            regression: null
+        def `test_log_scale_slider`:
+            Should be disabled with no tree: null
+            Normal: Sorazmerna
+            Should be disabled when no size adjustment: null
+            Square root: Kvadratni koren
+            Should be disabled when square root size adjustment: null
+            Logarithmic: Logaritmična
+            Should be enabled when square root size adjustment: null
+            Squares are drawn in same positions after changing log factor: null
+        def `test_checking_legend_checkbox_shows_and_hides_legend`:
+            Hiding legend failed: null
+            Showing legend failed: null
+        def `test_checking_tooltip_shows_and_hides_tooltips`:
+            Hiding tooltips failed: null
+            Showing tooltips failed: null
+        def `test_changing_max_depth_slider`:
+            Full tree should be drawn initially: null
+            Lowering tree depth limit did not hide squares: null
+            Increasing tree depth limit did not show squares: null
+        def `test_label_on_tree_connect_and_disconnect`:
+            Nodes:(.+)\s*Depth:(.+): Število vozlišč:(.+), globina:(.+)
+            Initial info should not contain node or depth info: null
+            Valid tree does not update info: null
+        def `test_tree_determinism`:
+            'The tree was not drawn identically in the %d times it was ': null
+            sent to widget after receiving the iris dataset.: null
+            tests: null
+            datasets: null
+            same_entropy.tab: null
+            'sent to widget after receiving a dataset with variables with ': null
+            same entropy.: null
+        def `test_forest_tree_table`:
+            titanic: null
+            housing: null
+        def `test_changing_data_restores_depth_from_previous_settings`:
+            titanic: null
+        def `test_context`:
+            iris: null
+    __main__: null
+widgets/visualize/tests/test_owpythagoreanforest.py:
+    class `TestOWPythagoreanForest`:
+        def `setUpClass`:
+            titanic: null
+            housing: null
+        def `test_migrate_version_1_settings`:
+            zoom: null
+            version: null
+        def `test_sending_rf_draws_trees`:
+            No trees should be drawn when no forest on input: null
+            Incorrect number of trees when forest on input: null
+            Trees are cleared when forest is disconnected: null
+        def `test_info_label`:
+            Trees:(.+): Drevesa:(.+)
+            Initial info should not contain info on trees: null
+            Valid RF does not update info: null
+            Removing RF does not clear info box: null
+        def `_get_first_tree`:
+            Empty list of tree widgets: null
+        def `test_changing_target_class_changes_coloring`:
+            def `_test`:
+                Colors did not change for %s data: null
+            classification: null
+            regression: null
+        def `test_context`:
+            iris: null
+    __main__: null
+widgets/visualize/tests/test_owradviz.py:
+    class `TestOWRadviz`:
+        def `setUpClass`:
+            Data: null
+            heart_disease: null
+        def `test_output_components`:
+            component: null
+            radviz-x: null
+            radviz-y: null
+            angle: null
+        def `test_discrete_attributes`:
+            zoo: null
+    __main__: null
+widgets/visualize/tests/test_owruleviewer.py:
+    class `TestOWRuleViewer`:
+        def `setUpClass`:
+            titanic: null
+            Classifier: null
+widgets/visualize/tests/test_owscatterplot.py:
+    class `TestOWScatterPlot`:
+        def `setUpClass`:
+            Data: null
+        def `test_score_heuristics`:
+            abcd: null
+            e: null
+            ab: null
+        def `test_data_column_nans`:
+            b: null
+            a: null
+        def `test_data_column_infs`:
+            b: null
+        def `test_group_selections`:
+            No: Ne
+            Yes: Da
+        def `test_saving_selection`:
+            selection: null
+        def `test_points_selection`:
+            selection_group: null
+            titanic: null
+        def `test_migrate_selection`:
+            selection_group: null
+        def `test_invalid_points_selection`:
+            selection_group: null
+        def `test_set_strings_settings`:
+            context_settings: null
+            attr_label: null
+            sepal length: null
+            attr_color: null
+            sepal width: null
+            attr_shape: null
+            iris: null
+            attr_size: null
+            petal width: null
+        def `test_features_and_no_data`:
+            iris: null
+        def `test_output_features`:
+            iris: null
+        def `test_vizrank`:
+            iris: null
+            housing: null
+        def `test_vizrank_class_nan`:
+            iris: null
+        def `test_vizrank_nonprimitives`:
+            zoo: null
+            Orange.widgets.visualize.owscatterplot.ReliefF: null
+        def `test_vizrank_enabled_no_data`:
+            No data on input: Ni podatkov na vhodu.
+        def `test_vizrank_enabled_sparse_data`:
+            Data is sparse: Podatki so redki.
+        def `test_vizrank_enabled_constant_data`:
+            c1: null
+            c2: null
+            c3: null
+            c4: null
+            cls: null
+            a: null
+            b: null
+        def `test_vizrank_enabled_two_features`:
+            Not enough features for ranking: Ni dovolj spremenljivk za rangiranje,
+        def `test_vizrank_enabled_no_color_var`:
+            Color variable is not selected: Barva ni določena,
+        def `test_vizrank_enabled_color_var_nans`:
+            c1: null
+            c2: null
+            c3: null
+            c4: null
+            cls: null
+            a: null
+            b: null
+            Color variable has no values: Spremenljivka z barvo nima znanih vrednosti.
+        def `test_auto_send_selection`:
+            iris: null
+        def `test_color_is_optional`:
+            zoo: null
+            backbone: null
+            breathes: null
+            airborne: null
+            type: null
+        def `test_handle_metas`:
+            iris: null
+        def `test_subset_data`:
+            iris: null
+        def `test_opacity_warning`:
+            iris: null
+        def `test_metas_zero_column`:
+            iris: null
+        def `test_tooltip`:
+            heart_disease: null
+            chest pain: null
+            cholesterol: null
+            mapFromScene: null
+            showText: null
+            pointsAt: null
+            age = {}: null
+            age: null
+            gender = {}: null
+            gender: null
+            max HR = {}: null
+            max HR: null
+            others: null
+            ... and 4 others: ... in še 4
+        def `test_many_discrete_values`:
+            def `prepare_data`:
+                iris: null
+                iris5: null
+        def `test_vizrank_receives_manual_change`:
+            Orange.widgets.visualize.owscatterplot.ScatterPlotVizRank.: null
+            on_manual_change: null
+            iris.tab: null
+        def `test_on_manual_change`:
+            iris.tab: null
+        def `test_update_regression_line_calls_add_line`:
+            '#505050': null
+        def `test_time_axis`:
+            time: null
+            value: null
+            bottom: null
+            axis should display floats: null
+        def `test_visual_settings`:
+            Helvetica: null
+            Fonts: null
+            Axis title: null
+            Font size: null
+            Italic: null
+            Axis ticks: null
+            tickFont: null
+            Line label: null
+            Figure: null
+            Lines: null
+            Width: null
+    __main__: null
+widgets/visualize/tests/test_owscatterplotbase.py:
+    class `MockWidget`:
+        Mock: null
+    class `TestOWScatterPlotBase`:
+        def `test_update_coordinates`:
+            data: null
+            size: null
+            symbol: null
+            pen: null
+            brush: null
+        def `test_update_coordinates_and_labels`:
+            a: null
+            b: null
+        def `test_update_coordinates_and_density`:
+            a: null
+            b: null
+        def `test_update_coordinates_reset_view`:
+            a: null
+            b: null
+        def `test_update_coordinates_indices`:
+            data: null
+        def `test_sampling`:
+            size: null
+            symbol: null
+            pen: null
+            get_label_data: null
+        Orange.widgets.visualize.owscatterplotgraph.OWScatterPlotBase.: null
+        def `test_reset_calls_all_updates_and_update_doesnt`:
+            update_sizes: null
+            update_colors: null
+            update_selection_colors: null
+            update_shapes: null
+            update_labels: null
+        def `test_size_normalization`:
+            size: null
+        def `test_size_rounding_half_pixel`:
+            size: null
+        def `test_size_with_nans`:
+            size: null
+        def `test_sizes_all_same_or_nan`:
+            size: null
+        def `test_sizes_point_width_is_linear`:
+            size: null
+        def `test_sizes_custom_imputation`:
+            size: null
+        def `test_sizes_selection`:
+            size: null
+        def `test_size_animation`:
+            Orange.widgets.visualize.owscatterplotgraph: null
+            .MAX_N_VALID_SIZE_ANIMATE: null
+        def `test_colors_discrete`:
+            pen: null
+            brush: null
+        def `test_colors_discrete_nan`:
+            pen: null
+            brush: null
+        def `test_colors_continuous_reused`:
+            pen: null
+            brush: null
+        def `test_colors_continuous_nan`:
+            pen: null
+            brush: null
+        def `test_colors_subset`:
+            def `run_tests`:
+                brush: null
+        def `test_colors_none`:
+            pen: null
+            brush: null
+        def `test_selection_colors`:
+            pen: null
+            AnyQt.QtWidgets.QApplication.keyboardModifiers: null
+        def `test_z_values`:
+            def `check_ranks`:
+                error at pair ({j}, {i}): null
+            setZ: null
+        def `test_z_values_with_sample`:
+            def `check_ranks`:
+                error at pair ({j}, {i}): null
+            setZ: null
+        def `test_density`:
+            Orange.widgets.utils.classdensity.class_density_image: null
+        def `test_density_with_missing`:
+            Orange.widgets.utils.classdensity.class_density_image: null
+        def `test_density_with_max_colors`:
+            Orange.widgets.visualize.owscatterplotgraph.MAX_COLORS: null
+            Orange.widgets.utils.classdensity.class_density_image: null
+        def `test_labels_observes_mask`:
+            1: null
+            2: null
+        def `test_shapes`:
+            symbol: null
+        def `test_shapes_nan`:
+            symbol: null
+            ?: null
+        def `test_show_legend`:
+            a: null
+            b: null
+            c: null
+            d: null
+            error at {}, {}: null
+        def `test_show_legend_no_data`:
+            a: null
+            b: null
+            c: null
+            d: null
+        def `test_legend_combine`:
+            a: null
+            b: null
+            c: null
+            d: null
+        def `test_select_by_click`:
+            AnyQt.QtWidgets.QApplication.keyboardModifiers: null
+        def `test_select_by_indices`:
+            def `select`:
+                AnyQt.QtWidgets.QApplication.keyboardModifiers: null
+        def `test_no_needless_buildatlas`:
+            atlas: null
+    class `TestScatterPlotItem`:
+        def `test_paint_mapping`:
+            pyqtgraph.ScatterPlotItem.paint: null
+        def `test_paint_mapping_exception`:
+            pyqtgraph.ScatterPlotItem.paint: null
+        def `test_paint_mapping_integration`:
+            pyqtgraph.ScatterPlotItem.paint: null
+    __main__: null
+widgets/visualize/tests/test_owsieve.py:
+    class `TestOWSieveDiagram`:
+        def `setUpClass`:
+            Data: null
+            titanic: null
+            iris: null
+        def `test_missing_values`:
+            c1: null
+            a: null
+            b: null
+            c: null
+            cls: null
+        def `test_chisquare`:
+            a: null
+            y: null
+            n: null
+            b: null
+            o: null
+            yynny: null
+            ynyyn: null
+        def `test_metadata`:
+            a: null
+            b: null
+            y: null
+            n: null
+            yynn: null
+            Orange.widgets.visualize.owsieve.Discretize: null
+        def `test_sparse_data`:
+            Data: null
+        def `test_vizrank_receives_manual_change`:
+            Orange.widgets.visualize.owsieve.SieveRank.on_manual_change: null
+            iris.tab: null
+    __main__: null
+widgets/visualize/tests/test_owsilhouetteplot.py:
+    class `TestOWSilhouettePlot`:
+        def `setUpClass`:
+            Data: null
+            Silhouette ({}): Silhueta ({})
+        def `setUp`:
+            auto_commit: null
+        def `test_nan_distances`:
+            Cosine: Kosinusna
+        def `test_ignore_categorical`:
+            heart_disease: null
+            Cosine: Kosinusna
+        def `test_meta_object_dtype`:
+            iris: null
+            S: null
+        def `test_memory_error`:
+            iris: null
+            numpy.asarray: null
+        def `test_bad_data_range`:
+            a: null
+            b: null
+            c: null
+            d: null
+            y: null
+            n: null
+            nyy: null
+        def `test_saved_selection`:
+            iris: null
+        def `test_distance_input`:
+            heart_disease: null
+        def `test_no_group_var`:
+            iris: null
+        def `test_unique_output_domain`:
+            Silhouette (iris): Silhueta (iris)
+            Silhouette (iris) (1): Silhueta (iris) (1)
+        def `test_report`:
+            zoo: null
+            nnotated: značen
+        def `test_migration`:
+            foo: null
+            bar: null
+            baz: null
+            bax: null
+            cfoo: null
+            mbaz: null
+            cluster_var_idx: null
+            annotation_var_idx: null
+            cluster_var: null
+            annotation_var: null
+    __main__: null
+widgets/visualize/tests/test_owtreegraph.py:
+    class `TestOWTreeGraph`:
+        def `setUpClass`:
+            Tree: null
+            tests: null
+            datasets: null
+            same_entropy.tab: null
+            aaa: null
+            e: null
+            f: null
+            g: null
+            bbb: null
+            ijkl: null
+            ccc: null
+            y: null
+        def `test_tree_determinism`:
+            'The tree was not drawn identically in the %d times it was ': null
+            sent to widget after receiving the iris dataset.: null
+            'sent to widget after receiving a dataset with variables with ': null
+            same entropy.: null
+        def `test_update_node_info`:
+            foo: null
+            bar<br/>ban: null
+            bar: null
+            bar<br/>ban<hr/>foo: null
+        def `test_tree_labels`:
+            42.0 ± 8.0: null
+            50 instances: 50 primerov
+            aaa: null
+            38.0 ± 5.0: null
+            16 instances: 16 primerov
+            bbb: null
+            13.0 ± 3.0: null
+            14 instances: 14 primerov
+            78.0 ± 12.0: null
+            20 instances: 20 primerov
+            ccc: null
+    __main__: null
+widgets/visualize/tests/test_owvenndiagram.py:
+    class `TestOWVennDiagram`:
+        def `test_rows_id`:
+            zoo: null
+            hair: null
+            feathers (1): null
+            feathers (2): null
+            eggs: null
+            milk: null
+            airborne: null
+            aquatic: null
+            predator: null
+            toothed: null
+            backbone: null
+            breathes: null
+            venomous: null
+            fins: null
+            legs: null
+            tail: null
+            domestic: null
+            catsize: null
+        def `test_disable_duplicates`:
+            zoo: null
+        def `test_disable_match_equality`:
+            zoo: null
+        def `test_multiple_input_over_cols`:
+            Selected: null
+            Data: null
+            sepal length (2): null
+            sepal length (1): null
+        def `test_unconditional_commit_on_new_signal`:
+            now: null
+        def `test_rows_identifiers`:
+            zoo: null
+            Data: null
+        def `test_migration_to_3`:
+            selected_feature: null
+    __main__: null
+widgets/visualize/tests/test_owviolinplot.py:
+    class `TestOWViolinPlot`:
+        def `setUpClass`:
+            Data: null
+            housing: null
+        def `test_no_cont_features`:
+            zoo: null
+        def `test_enable_controls`:
+            None: (Brez skupin)
+        def `test_show_grid_sets_show_grid`:
+            Orange.widgets.visualize.owviolinplot.ViolinPlot.set_show_grid: null
+        def `test_show_grid_orientation`:
+            bottom: null
+            left: null
+        def `test_unique_values`:
+            petal width: null
+        def `test_select`:
+            mapToView: null
+        def `test_selection_rect`:
+            mapToView: null
+        def `test_selection_sort_violins`:
+            sepal width: null
+        def `test_saved_selection`:
+            AnyQt.QtWidgets.QApplication.keyboardModifiers: null
+        def `test_visual_settings`:
+            def `test_settings`:
+                Helvetica: null
+                tickFont: null
+                Foo: null
+                rotateTicks: null
+            Fonts: null
+            Font family: null
+            Helvetica: null
+            Title: null
+            Font size: null
+            Italic: null
+            Axis title: null
+            Axis ticks: null
+            Annotations: null
+            Foo: null
+            Figure: null
+            Bottom axis: null
+            Vertical tick text: null
+    __main__: null
+widgets/visualize/tests/test_vizrankdialog.py:
+    class `TestRunner`:
+        def `setUpClass`:
+            iris: null
+    __main__: null
+widgets/visualize/utils/tests/test_customizableplot.py:
+    class `TestFonts`:
+        def `test_available_font_families`:
+            QFont: null
+            QFontDatabase: null
+            mock regular: null
+            a: null
+            .d: null
+            e: null
+            .b: null
+            c: null
+            mock bold: null
+            mock italic: null
+            mock semi: null
+    __main__: null
+widgets/visualize/utils/tests/test_heatmap.py:
+    class `TestHeatmapGridWidget`:
+        0-0: null
+        1-0: null
+        0-1: null
+        a: null
+        1-1: null
+        b: null
+        2-2-split: null
+        2-2-cl: null
+        2-2: null
+        def `test_widget_annotations`:
+            2-2: null
+            1: null
+            2: null
+            a: null
+            b: null
+        def `test_selection`:
+            2-2: null
+        def `test_colormap`:
+            2-2: null
+    class `TestCategoricalColorLegend`:
+        def `test_font_propagation`:
+            a: null
+            b: null
+            Title: null
+            Windings: null
+widgets/visualize/utils/tests/test_plotutils.py:
+    class `TestInteractiveViewBox`:
+        def `test_update_scale_box`:
+            mapToView: null
+    __main__: null
+widgets/visualize/utils/tree/tests/test_rules.py:
+    class `TestRules`:
+        def `test_merging_two_gt_continuous_rules`:
+            Rule: null
+        def `test_merging_gt_with_gte_continuous_rule`:
+            Rule: null
+        def `test_merging_two_lt_continuous_rules`:
+            Rule: null
+        def `test_merging_lt_with_lte_rule`:
+            Rule: null
+        def `test_merging_lt_with_gt_continuous_rules`:
+            Rule: null
+        def `test_merging_interval_rule_with_smaller_continuous_rule`:
+            Rule: null
+        def `test_merging_interval_rule_with_larger_continuous_rule`:
+            Rule: null
+        def `test_merging_interval_rule_with_larger_lt_continuous_rule`:
+            Rule: null
+        def `test_merging_interval_rule_with_smaller_gt_continuous_rule`:
+            Rule: null
+        def `test_merging_interval_rules_with_smaller_lt_component`:
+            Rule: null
+        def `test_merging_interval_rules_with_larger_lt_component`:
+            Rule: null
+        def `test_merging_interval_rules_generally`:
+            Rule: null
+        def `test_merge_commutativity_on_continuous_rules`:
+            Rule1: null
+        def `test_merge_commutativity_on_interval_rules`:
+            Rule: null
+        def `test_merge_keeps_gt_on_continuous_rules`:
+            Rule1: null
+        def `test_merge_keeps_attr_name_on_continuous_rules`:
+            Rule1: null
+widgets/visualize/utils/tree/tests/test_treeadapter.py:
+    class `TestTreeAdapter`:
+        def `setUp`:
+            v1: null
+            v2: null
+            abc: null
+            v3: null
+            def: null
+            y: null
+        def `test_adapter`:
+            v1 > 13: null

--- a/si/orange3.jaml
+++ b/si/orange3.jaml
@@ -198,8 +198,8 @@ util.py:
             unsafe: false
 version.py:
     3.35.0: false
-    3.35.0.dev0+c42459a: false
-    c42459a428b30c90f3a1cfdb6d2ab0e755776c4a: false
+    3.35.0.dev0+511fbaa: null
+    511fbaa29b98505c51f944353bad72378b34eb84: null
     .dev: false
 canvas/__main__.py:
     ORANGE_STATISTICS_API_URL: false
@@ -4218,7 +4218,7 @@ widgets/data/owaggregatecolumns.py:
         Product: Produkt
         Min: false
         Minimal value: Najmanjša vrednost
-        Max: Maksimum
+        Max: false
         Maximal value: Največja vrednost
         Mean: false
         Mean value: Povprečna vrednost
@@ -4308,7 +4308,7 @@ widgets/data/owcolor.py:
             Duplicated variable names: Podvojena imena spremenljivk
             Variables will not be renamed due to duplicated names.: Zaradi podvojenih imen spremenljivke ne bodo preimenovane.
             "'{name}'": false
-            'Definition for variable {names[0]}, which does not ': Nastavitve za spremenljivko {names[0]}, ki je ni v podatkih,
+            'Definition for variable {names[0]}, which does not ': 'Nastavitve za spremenljivko {names[0]}, ki je ni v podatkih, '
             appear in the data, was ignored.\n: niso uporabljene.\n
             'Definitions for variables ': Nastavitve za {plsi(len(names), "|spremenljivki|spremenljivke")}
             {", ".join(names[:-1])} and {names[-1]}: {", ".join(names[:-1])} in {names[-1]}
@@ -4593,7 +4593,7 @@ widgets/data/owcreateclass.py:
 widgets/data/owcreateinstance.py:
     class `DiscreteVariableEditor`:
         def `__init__`:
-            ?: (nedoločeno)
+            ?: false
     class `ContinuousVariableEditor`:
         def `__init__`:
             Min/Max cannot be NaN.: false
@@ -4665,7 +4665,7 @@ widgets/data/owcsvimport.py:
         def `__init__`:
             utf-8: false
             ColumnType: false
-            .: ,
+            .: true
         def `__repr__`:
             {}{!r}: false
         def `as_dict`:
@@ -4689,7 +4689,7 @@ widgets/data/owcsvimport.py:
             columntypes: false
             rowspec: false
             decimal_separator: false
-            .: ,
+            .: true
             group_separator: false
         def `spec_as_encodable`:
             start: false
@@ -4878,7 +4878,7 @@ widgets/data/owcsvimport.py:
             category: false
             object: false
         X.: false
-        .: ,
+        .: true
         decimal: false
         thousands: false
         float_precision: false
@@ -5483,7 +5483,7 @@ widgets/data/oweditdomain.py:
             ' (reinterpreted as ': ' (pretolmačena v '
             {self.ReinterpretNames[type(tr)]}): true
         def `helpEvent`:
-            Name `{name}` is duplicated: Ime '{ime}' je podvojeno.
+            Name `{name}` is duplicated: Ime '{name}' je podvojeno.
     class `ReinterpretVariableEditor`:
         def `__init__`:
             def `decorate`:
@@ -6710,7 +6710,7 @@ widgets/data/owpivot.py:
             row_feature: false
             Columns: Stolpci
             col_feature: false
-            (Same as rows): (Enako vrsticam)
+            (Same as rows): (Enako kot vrstice)
             Values: Vrednosti
             val_feature: false
             (None): (Brez)
@@ -7218,22 +7218,22 @@ out_data = Table.from_numpy(domain, arr)
         program: program
         function: funkcija
         class `Inputs`:
-            Data: Podatki
+            Data: false
             in_data: false
-            Learner: Učenec
+            Learner: false
             in_learner: false
-            Classifier: Model
+            Classifier: false
             in_classifier: false
-            Object: Objekt
+            Object: false
             in_object: false
         class `Outputs`:
-            Data: Podatki
+            Data: false
             out_data: false
-            Learner: Učenec
+            Learner: false
             out_learner: false
-            Classifier: Model
+            Classifier: false
             out_classifier: false
-            Object: Objekt
+            Object: false
             out_object: false
         data: false
         learner: false
@@ -7692,7 +7692,7 @@ widgets/data/owselectrows.py:
         ends with: se konča z
         end with: se končajo z
         All variables: Vse spremenljivke
-        All numeric variables: Vse številke spremenljivke
+        All numeric variables: Vse številske spremenljivke
         All string variables: Vse besedilne spremenljivke
         class `Error`:
             {}: false
@@ -7722,7 +7722,7 @@ widgets/data/owselectrows.py:
             Type %s not supported.: false
         def `set_new_values`:
             defined: znan
-            ' one of': ' eden izmed '
+            ' one of': ' eden izmed'
             ' and ': ' in '
         def `_values_to_floats`:
             Some values could not be parsed as floats: Nekaterih vrednosti ni mogoče prebrati kot števila
@@ -8859,7 +8859,7 @@ widgets/evaluate/owpredictions.py:
         def `_get_details`:
             Data:<br>: Podatki:<br>
             <hr>: false
-            'Model: {number} model{s}': Modeli: {number} {plsi(numerv, "model")}
+            "Model: {n_predictors} {pl(n_predictors, 'model')}": Modeli: {n_predictors} {plsi(n_predictors, "model")}
             ' ({n_predictors - n_valid} failed)': ' ({n_predictors - n_valid} z napako)'
             <ul>: false
             <li>{name}</li>: false
@@ -11164,7 +11164,7 @@ widgets/unsupervised/owmds.py:
             Start: Začni
             Refresh:: Izris:
             refresh_rate: false
-            'Kruskal Stress: -': 'Kruskalova napetost: -'
+            'Kruskal Stress: -': Kruskalova napetost: -
         def `_initialize`:
             labels: false
         def `init_attr_values`:
@@ -11180,7 +11180,7 @@ widgets/unsupervised/owmds.py:
         def `update_stress`:
             -: false
             {self.stress:.3f}: false
-            'Kruskal Stress: {stress_val}': 'Kruskalova napetost: {stress_val}'
+            'Kruskal Stress: {stress_val}': Kruskalova napetost: {stress_val}
         def `on_exception`:
             Start: Začni
         def `do_initialization`:
@@ -11188,7 +11188,7 @@ widgets/unsupervised/owmds.py:
         def `get_size_data`:
             Stress: Napetost
         def `get_stress`:
-            euclidean: evklidski
+            euclidean: false
         def `migrate_settings`:
             label_only_selected: false
             symbol_opacity: false
@@ -11755,7 +11755,7 @@ widgets/utils/domaineditor.py:
         skip: izpusti
         categorical: kategorična
         numeric: številska
-        text: besedila
+        text: besedilna
         datetime: časovna
         def `headerData`:
             Name: Ime
@@ -12047,10 +12047,6 @@ widgets/utils/itemmodels.py:
                 {}={}: false
             def `format_sparse_bool`:
                 ', ': false
-            def `make_basket_formater`:
-                sparse_x: false
-                sparse_y: false
-                sparse_metas: false
             len(sourcedata) > 2 ** 31 - 1: false
         def `columnSortKeyData`:
             Orange.widgets.utils.itemmodels.TableModel.sortColumnData: false
@@ -13647,7 +13643,7 @@ widgets/visualize/ownomogram.py:
     ': false
     class `ProbabilitiesDotItem`:
         def `get_tooltip_text`:
-            'Total: {} <br/>Probability: {:.0%}': Vsota: {} <br/>Verjetnost: {:.0}&nbsp;%
+            'Total: {} <br/>Probability: {:.0%}': Vsota: {} <br/>Verjetnost: {:.0%}
     class `DiscreteMovableDotItem`:
         def `get_tooltip_text`:
             'Points: {}': Točke: {}

--- a/si/test_config.yaml
+++ b/si/test_config.yaml
@@ -1,0 +1,1 @@
+exclude-pattern: ''


### PR DESCRIPTION
Bad news:

- We will have to run tests on translated Orange, too.
- Just marking some tests as language-dependent won't do: there would be too many of them and I've seen bugs that we would overlook if we just skipped tests. Hence, we will need to translate tests as well.

I wanted to avoid adding strings from tests to translations because it would (almost exactly) double the file length. Therefore I've put them in a separate file, which is to be treated by different standards: the actual translations should (in principle) have no `null`'s, while for tests nulls are OK - we only translate what is necessary.

Besides translations for tests, this PR includes some other small fixes.
