### PR TITLE
Typo in translation show:

### DIFF
--- a/si/orange3-geo.jaml
+++ b/si/orange3-geo.jaml
@@ -1151,7 +1151,7 @@ widgets/owchoropleth.py:
             agg_attr: false
             Values:: Vrednost:
             agg_func: false
-            Show:: Pokaži::
+            Show:: Pokaži:
             binning_index: false
             Bin width:: Širina intervala
             graph.alpha_value: false


### PR DESCRIPTION
In translation, there was written: `Show:: Pokaži::` instead od `Show:: Pokaži:`. One colon `:` too many.